### PR TITLE
Add superslab filtering functionality

### DIFF
--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -175,3 +175,15 @@ def test_unpack_bits():
     # bad bits field name
     with pytest.raises(ValueError):
         cat = CompaSOHaloCatalog(os.path.join(EXAMPLE_SIM, 'halos', 'z0.000'), subsamples=True, unpack_bits=['blah'], fields='N')
+
+def test_filter_func():
+    '''Test CHC filter_func
+    '''
+    
+    from abacusnbody.data.compaso_halo_catalog import CompaSOHaloCatalog
+
+    cat = CompaSOHaloCatalog(os.path.join(EXAMPLE_SIM, 'halos', 'z0.000'), fields=['N','x_L2com'],
+                            filter_func = lambda c: c['N'] > 100)
+    print(len(cat.halos))
+    assert (cat.halos['N'] > 100).all()
+    #assert len(cat.halos) == 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -73,8 +73,19 @@ def test_subsamples_unclean(tmp_path):
     '''
 
     from abacusnbody.data.compaso_halo_catalog import CompaSOHaloCatalog
+    
+    cat = CompaSOHaloCatalog(os.path.join(EXAMPLE_SIM, 'halos', 'z0.000'), subsamples=dict(A=True), fields='all', cleaned=False)
+    lenA = len(cat.subsamples)
+    assert lenA == 2975
+    assert cat.subsamples.colnames == ['pos', 'vel']
+    
+    cat = CompaSOHaloCatalog(os.path.join(EXAMPLE_SIM, 'halos', 'z0.000'), subsamples=dict(B=True), fields='all', cleaned=False)
+    lenB = len(cat.subsamples)
+    assert lenB == 7082
 
     cat = CompaSOHaloCatalog(os.path.join(EXAMPLE_SIM, 'halos', 'z0.000'), subsamples=True, fields='all', cleaned=False)
+    
+    assert len(cat.subsamples) == lenA + lenB
 
     # to regenerate reference
     #ref = cat.subsamples
@@ -176,6 +187,7 @@ def test_unpack_bits():
     with pytest.raises(ValueError):
         cat = CompaSOHaloCatalog(os.path.join(EXAMPLE_SIM, 'halos', 'z0.000'), subsamples=True, unpack_bits=['blah'], fields='N')
 
+
 def test_filter_func():
     '''Test CHC filter_func
     '''
@@ -183,7 +195,8 @@ def test_filter_func():
     from abacusnbody.data.compaso_halo_catalog import CompaSOHaloCatalog
 
     cat = CompaSOHaloCatalog(os.path.join(EXAMPLE_SIM, 'halos', 'z0.000'), fields=['N','x_L2com'],
-                            filter_func = lambda c: c['N'] > 100)
-    print(len(cat.halos))
+                            filter_func = lambda c: c['N'] > 100,
+                            subsamples=True)
     assert (cat.halos['N'] > 100).all()
     assert len(cat.halos) == 146
+    assert len(cat.subsamples) == 7193

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -186,4 +186,4 @@ def test_filter_func():
                             filter_func = lambda c: c['N'] > 100)
     print(len(cat.halos))
     assert (cat.halos['N'] > 100).all()
-    #assert len(cat.halos) == 
+    assert len(cat.halos) == 146


### PR DESCRIPTION
This PR introduces a feature for filtering rows from the halo table on a per-superslab basis as they are loaded into memory.  This saves memory, since the full, unfiltered table never needs to be constructed.  Syntax is a function passed to the CHC constructor, often a lambda:
```python
cat = CompaSOHaloCatalog('/mnt/home/lgarrison/ceph/AbacusSummit/AbacusSummit_hugebase_c000_ph000/halos/z0.100/',
                         fields=['N','x_L2com'],
                         filter_func=lambda c: c['N'] >= 100,
                        )
```

If requesting subsamples, only the subsamples from the surviving halos are loaded, but the peak memory usage is still higher than it needs to be.  This part of the code needs a refactor anyways (#7), but that's a future issue.

This required a bit of refactoring of how the cleaning files are read; now the original and cleaned files are read as a pair for each superslab, rather than all the originals, then all the cleaning.
