### PR TITLE
Add MacOS CI config

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,10 +5,14 @@ on: [push]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
+        include:
+          - os: macos-latest
+            python-version: "3.10"
 
     steps:
     - uses: actions/checkout@v2

--- a/abacusnbody/common.py
+++ b/abacusnbody/common.py
@@ -1,0 +1,17 @@
+'''Common utility functions.
+'''
+
+def maxthreads():
+    '''Return the number of logical cores available to this process.
+    First tries the affinity mask, then the total number of CPUs,
+    then 1 if all else fails.
+    '''
+    import multiprocessing
+    import os
+    
+    try:
+        maxthreads = len(os.sched_getaffinity(0))
+    except AttributeError:
+        maxthreads = multiprocessing.cpu_count() or 1
+        
+    return maxthreads

--- a/abacusnbody/data/compaso_halo_catalog.py
+++ b/abacusnbody/data/compaso_halo_catalog.py
@@ -290,10 +290,11 @@ except Exception as e:
     raise Exception("Abacus ASDF extension not properly loaded! Try reinstalling abacusutils, or updating ASDF: `pip install asdf>=2.8`") from e
 
 from . import bitpacked
+from ..common import maxthreads
 
 # Default to 4 decompression threads, or fewer if fewer cores are available
 DEFAULT_BLOSC_THREADS = 4
-DEFAULT_BLOSC_THREADS = max(1, min(len(os.sched_getaffinity(0)), DEFAULT_BLOSC_THREADS))
+DEFAULT_BLOSC_THREADS = max(1, min(maxthreads(), DEFAULT_BLOSC_THREADS))
 from . import asdf as _asdf
 _asdf.set_nthreads(DEFAULT_BLOSC_THREADS)
 
@@ -1741,4 +1742,3 @@ user_dt = np.dtype([('id', np.uint64),
                     ('sigmavtan_L2com', np.float32),
                     ('rvcirc_max_L2com', np.float32),
 ], align=True)
- 


### PR DESCRIPTION
From #58 , add a cross-platform fallback to the max threads detection, and add a MacOS CI config.

No telling if the rest of the code is MacOS safe. Let's find out!