### PR TITLE
Re-enable Numba parallelism in environment calculation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+1.4.0 (upcoming)
+----------------
+
+Fixes
+~~~~~
+- Bump Numba requirement to fixed version and enable parallelism in env calc [#60]
+
 1.3.0 (2022-06-08)
 ------------------
 

--- a/abacusnbody/hod/abacus_hod.py
+++ b/abacusnbody/hod/abacus_hod.py
@@ -218,6 +218,24 @@ Notes
 Currently, when RSD effects are enabled in the HOD code for the halo light cones, the
 factor ``velz2kms``, determining the size of the RSD correction to the position along
 the line of sight, is the same for all galaxies at a given redshift catalog.
+
+
+Parallelism
+===========
+Some of the HOD routines accept an ``Nthread`` argument to enable parallelism. This parallelism
+is backed by `Numba <https://numba.readthedocs.io/en/stable/user/index.html>`_, for the most part.
+
+This has implications if the HOD module is used as part of a larger code. Numba supports multiple
+`threading backends <https://numba.readthedocs.io/en/stable/user/threading-layer.html#selecting-a-threading-layer-for-safe-parallel-execution>`_,
+some of which will not work if the larger code uses other flavors of parallelism. In such cases,
+you may need to instruct Numba to use a fork-safe and/or thread-safe backend (called ``forksafe``
+and ``threadsafe``), depending on whether the larger code is forking subprocesses or spawning
+threads. This can be accomplished by setting the environment variable ``NUMBA_THREADING_LAYER=forksafe``
+or assigning ``numba.config.THREADING_LAYER='forksafe'`` in Python before importing the HOD
+code (likewise for ``threadsafe``).  There is also a ``safe`` backend that is both fork- and thread-safe,
+but it is only available if Intel TBB is available. See the `Numba threading layer docs <https://numba.readthedocs.io/en/stable/user/threading-layer.html>`_
+for more info.
+
 """
 import os
 import glob

--- a/abacusnbody/hod/prepare_sim.py
+++ b/abacusnbody/hod/prepare_sim.py
@@ -217,7 +217,7 @@ def concat_to_arr(lists, dtype=np.int64):
     res = np.fromiter(itertools.chain.from_iterable(lists), count=N, dtype=dtype)
     return res, starts
 
-@njit(parallel=False)
+@njit(parallel=True)
 def calc_Menv(masses, inner_arr, inner_starts, outer_arr, outer_starts):
     N = len(inner_starts)-1
     Menv = np.zeros(N, dtype=np.float32)
@@ -233,7 +233,7 @@ def calc_Menv(masses, inner_arr, inner_starts, outer_arr, outer_starts):
         Menv[p] = outer_mass - inner_mass
     return Menv
 
-@njit(parallel=False)
+@njit(parallel=True)
 def calc_fenv_opt(Menv, mbins, halosM):
     fenv_rank = np.zeros(len(Menv))
     for ibin in numba.prange(len(mbins)-1):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 
 from setuptools import setup, find_namespace_packages
 
-install_requires = ['numpy>=1.16','blosc>=1.9.2','astropy>=4.0.0','scipy>=1.5.0','numba>=0.50','asdf>=2.8','h5py','pyyaml']
+install_requires = ['numpy>=1.16','blosc>=1.9.2','astropy>=4.0.0','scipy>=1.5.0','numba>=0.56','asdf>=2.8','h5py','pyyaml']
 
 # enable "pip install abacusutils[test]" and "abacusutils[extra]"
 # "extra" will be everything used by scripts but not the importable code

--- a/tests/test_hod.py
+++ b/tests/test_hod.py
@@ -21,6 +21,9 @@ from astropy.io import ascii
 
 from common import check_close
 
+# required for pytest to work (see GH #60)
+import numba
+numba.config.THREADING_LAYER='forksafe'
 
 TESTDIR = dirname(__file__)
 REFDIR = pjoin(dirname(__file__), 'ref_hod')

--- a/tests/test_lc_hod.py
+++ b/tests/test_lc_hod.py
@@ -18,6 +18,10 @@ from astropy.io import ascii
 
 from common import check_close
 
+# required for pytest to work (see GH #60)
+import numba
+numba.config.THREADING_LAYER='forksafe'
+
 TESTDIR = dirname(__file__)
 REFDIR = pjoin(dirname(__file__), 'ref_hod')
 EXAMPLE_SIM = pjoin(TESTDIR, 'AbacusSummit_base_c000_ph001-abridged')


### PR DESCRIPTION
Now that Numba 0.56 is out, we can fix #47 by bumping the Numba version requirement. The `forksafe` threading layer is once again fork safe, so we can have the tests select it automatically so they will run. In some cases, end users may also need to select this threading layer. I've added docs about it just in case.

@SandyYuan hopefully this speeds up the code a little!