### PR TITLE
Update metadata module with power spectrum

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@ Fixes
 ~~~~~
 - Bump Numba requirement to fixed version and enable parallelism in env calc [#60]
 
+Enhancements
+~~~~~~~~~~~~
+- Add power spectrum to `metadata` module [#69]
+
 1.3.0 (2022-06-08)
 ------------------
 

--- a/abacusnbody/metadata/abacussummit.py
+++ b/abacusnbody/metadata/abacussummit.py
@@ -4,7 +4,7 @@ AbacusSummit simulations.
 '''
 
 import importlib.resources
-import pickle
+import msgpack
 
 import asdf
 
@@ -35,12 +35,13 @@ def get_meta(simname, redshift=None):
         simname = 'AbacusSummit_' + simname
     
     global metadata
-    if metadata == None:
+    if metadata is None:
         with importlib.resources.open_binary('abacusnbody.metadata', metadata_fn) as fp, asdf.open(fp) as af:
-            if 'pickle' in af.tree:
-                metadata = pickle.loads(af['pickle'][:])
-            else:
-                metadata = dict(af.tree)
+            metadata = dict(af.tree)
+            del metadata['asdf_library'], metadata['history']
+            for sim in metadata:
+                metadata[sim]['param'] = msgpack.loads(metadata[sim]['param'].data, strict_map_key=False)
+                metadata[sim]['state'] = msgpack.loads(metadata[sim]['state'].data, strict_map_key=False)
     
     if simname not in metadata:
         raise ValueError(f'Simulation "{simname}" is not in metadata file "{metadata_fn}"')

--- a/scripts/metadata/compress.py
+++ b/scripts/metadata/compress.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 import pickle
+import json
 
 import click
 import asdf
@@ -12,7 +13,9 @@ import numpy as np
 @click.option('--rmstate', default=False, is_flag=True)
 @click.option('--rmpk', default=False, is_flag=True)
 @click.option('--pickle', 'dopickle', default=False, is_flag=True)
-def compress(fn, rmstate, rmpk, dopickle):
+@click.option('--msgpack', 'domsgpack', default=True, is_flag=True)
+@click.option('--json', 'dojson', default=False, is_flag=True)
+def compress(fn, rmstate, rmpk, dopickle, domsgpack, dojson):
     '''Compress metadata file FN
     '''
     fn = Path(fn)
@@ -28,13 +31,61 @@ def compress(fn, rmstate, rmpk, dopickle):
             del meta[k]['CLASS_power_spectrum']
 
     if dopickle:
-        p = pickle.dumps(meta)
-        meta = dict(pickle=np.frombuffer(p, dtype=np.byte))
+        for sim in meta:
+            meta[sim]['state'] = np.frombuffer(pickle.dumps(meta[sim]['state']), dtype=np.byte)
+            meta[sim]['param'] = np.frombuffer(pickle.dumps(meta[sim]['param']), dtype=np.byte)
+        
+        # p = pickle.dumps(meta)
+        # meta = dict(pickle=np.frombuffer(p, dtype=np.byte))
+    
+    if domsgpack:
+        import msgpack
+        for sim in meta:
+            meta[sim]['state'] = np.frombuffer(msgpack.dumps(meta[sim]['state']), dtype=np.byte)
+            meta[sim]['param'] = np.frombuffer(msgpack.dumps(meta[sim]['param']), dtype=np.byte)
+
+    if dojson:
+        for sim in meta:
+            meta[sim]['state'] = np.frombuffer(json.dumps(meta[sim]['state']).encode(), dtype=np.byte)
+            meta[sim]['param'] = np.frombuffer(json.dumps(meta[sim]['param']).encode(), dtype=np.byte)
+        
+        # p = pickle.dumps(meta)
+        # meta = dict(pickle=np.frombuffer(p, dtype=np.byte))
+
+    if not rmpk:
+        # de-dup
+        for i,sim1 in enumerate(meta):
+            pk1 = meta[sim1]['CLASS_power_spectrum']
+            for j,sim2 in list(enumerate(meta))[i+1:]:
+                pk2 = meta[sim2]['CLASS_power_spectrum']
+                for col in pk1.colnames:
+                    if np.array_equal(pk1[col], pk2[col]):
+                        pk2.replace_column(col, pk1[col], copy=False)
+
     
     with asdf.AsdfFile(tree=meta) as af:
+        # the following needs https://github.com/astropy/asdf-astropy/issues/156
+        # for sim in meta:
+        #     for k in ('state','param'):
+        #         af.set_array_compression(af[sim][k], 'blsc',
+        #             shuffle='shuffle', compression_block_size=1<<15, blosc_block_size=1<<30, clevel=9, cname='zstd',
+        #         )
+            # if 'CLASS_power_spectrum' in af[sim]:
+            #     for k in ('k (h/Mpc)', 'P (Mpc/h)^3'):
+            #         af.set_array_compression(af[sim]['CLASS_power_spectrum'][k], 'lz4',
+            #             shuffle='shuffle', compression_block_size=1<<22, blosc_block_size=1<<18, clevel=9, cname='zstd',
+            #             typesize=8,
+            #         )
         af.write_to(fn.parent / (fn.stem + "_compressed.asdf"),
-        all_array_compression='blsc',
-        compression_kwargs=dict(shuffle=None, compression_block_size=1<<30, blosc_block_size=1<<30, clevel=9),
+            all_array_compression='blsc',
+            compression_kwargs = dict(
+                shuffle='shuffle',
+                compression_block_size=1<<22,
+                blosc_block_size=1<<20,
+                clevel=9,
+                cname='zstd',
+                #typesize=16,
+            ),
         )
 
 if __name__ == '__main__':

--- a/scripts/metadata/gather_metadata.py
+++ b/scripts/metadata/gather_metadata.py
@@ -9,7 +9,9 @@ from tqdm import tqdm
 
 from Abacus.InputFile import InputFile
 
-ABACUSSUMMIT = Path(os.getenv('CFS',' /global/cfs/cdirs')) / 'desi/cosmosim/Abacus'
+ABACUSSUMMIT = Path(os.getenv('CFS', '/global/cfs/cdirs')) / 'desi/cosmosim/Abacus'
+COSMOLOGIES = Path(os.getenv('ABACUS')) / 'external/AbacusSummit/Cosmologies'
+COSM_KEYS = ('A_s', 'alpha_s')
 
 def get_state(fn):
     with open(fn) as fp:
@@ -20,19 +22,25 @@ def get_state(fn):
     return dict(InputFile(str_source=statestr))
 
 @click.command()
-def main():
+@click.option('--small', is_flag=True)
+def main(small=False):
     '''Gather the simulation headers from the IC files.
 
-    We use the IC files because they contain the growth tables, which
-    the other headers don't.
+    We use the IC files because they contain the growth tables
+    and linear Pk, which the other headers don't.
     '''
     icdir = ABACUSSUMMIT / 'ic'
 
-    simnames = sorted(list(ABACUSSUMMIT.glob('AbacusSummit_*')))
+    if not small:
+        simnames = sorted(list(ABACUSSUMMIT.glob('AbacusSummit_*'))) + \
+            [ABACUSSUMMIT / 'small' / 'AbacusSummit_small_c000_ph3000']
+    else:
+        simnames = sorted(list((ABACUSSUMMIT / 'small').glob('AbacusSummit_*')))
 
     headers = {}
     for i,sim in enumerate(tqdm(simnames)):
         param = dict(InputFile(sim / 'abacus.par'))  # static
+        ctag = sim.name.split('_')[-2][1:]  # '000'
 
         state = {}
         for zdir in (sim / 'halos').glob('z*'):
@@ -49,11 +57,23 @@ def main():
             
             state[zdir.name] = {k:v for k,v in zheader.items() if k not in param}
 
-        with asdf.open(icdir / sim.name / 'ic_dens_N576.asdf', lazy_load=True, copy_arrays=True) as af:
+        if 'small' in sim.name:
+            _icdir = icdir / 'small'
+        else:
+            _icdir = icdir
+
+        with asdf.open(_icdir / sim.name / 'ic_dens_N576.asdf', lazy_load=True, copy_arrays=True) as af:
             icparam = af['header'].copy()
             class_pk = af['CLASS_power_spectrum'].copy()
-            icparam.update(param)  # conflicts revert to param
-            param = icparam
+        
+        icparam.update(param)  # conflicts revert to param
+        param = icparam
+
+        class_ini = dict(InputFile(COSMOLOGIES / f'abacus_cosm{ctag}' / 'CLASS.ini'))
+        for k in COSM_KEYS:
+            assert k not in param
+            assert k not in state
+            param[k] = class_ini[k]
         
         headers[sim.name] = {}
         headers[sim.name]['param'] = param

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ install_requires = ['numpy>=1.16','blosc>=1.9.2','astropy>=4.0.0','scipy>=1.5.0'
 # enable "pip install abacusutils[test]" and "abacusutils[extra]"
 # "extra" will be everything used by scripts but not the importable code
 extras_require = dict(test=['pytest'],
-                      extra=['emcee','schwimmbad','getdist','dynesty','dill', 'click'],
+                      extra=['emcee','schwimmbad','getdist','dynesty','dill', 'click', 'msgpack'],
                     )
 
 # If we're on ReadTheDocs, can't install packages with C dependencies, like Corrfunc

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,12 @@ import os
 
 from setuptools import setup, find_namespace_packages
 
-install_requires = ['numpy>=1.16','blosc>=1.9.2','astropy>=4.0.0','scipy>=1.5.0','numba>=0.56','asdf>=2.8','h5py','pyyaml']
+install_requires = ['numpy>=1.16','blosc>=1.9.2','astropy>=4.0.0','scipy>=1.5.0','numba>=0.56','asdf>=2.8','h5py','pyyaml','msgpack>=1']
 
 # enable "pip install abacusutils[test]" and "abacusutils[extra]"
 # "extra" will be everything used by scripts but not the importable code
 extras_require = dict(test=['pytest'],
-                      extra=['emcee','schwimmbad','getdist','dynesty','dill', 'click', 'msgpack'],
+                      extra=['emcee','schwimmbad','getdist','dynesty','dill', 'click'],
                     )
 
 # If we're on ReadTheDocs, can't install packages with C dependencies, like Corrfunc

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -10,3 +10,4 @@ def test_meta():
     assert meta['SimName'] == 'AbacusSummit_base_c000_ph000'
     assert meta['OmegaNow_m'] == 0.379887444945823
     assert meta['GrowthTable'][1.] == 47.30480505646196
+    assert meta['CLASS_power_spectrum']['k (h/Mpc)'][0] == 2.097837747762e-07


### PR DESCRIPTION
Adds the power spectrum, `A_s`, and `alpha_s` to the metadata module. Also adds a single small sim.

Most of the power spectra are actually the same (`c000_ph000`), so we can de-dup the data on disk by having all the astropy tables use the same underlying columns (this is done in `compress.py`).  The resulting ASDF files have separate entries for each astropy table in the tree, but the `source` tag for the columns (i.e. the corresponding binary block) is the same.

The metadata file is 9 MB, which is probably okay.  We could tune this a bit more if astropy/asdf-astropy#156 gets implemented.

We now use msgpack on the params instead of pickle. The compression of json, pickle, and msgpack is the same, but msgpack is portable and supports non-string dict keys.

Closes #61.
