### PR TITLE
ci: add python 3.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3
@@ -23,7 +23,7 @@ jobs:
       run: |
         python -m pip install -U pip
         pip install numpy
-        pip install .[test]
+        pip install -U .[test]
         make -C pipe_asdf
     - name: Test Python with pytest
       run: |
@@ -47,7 +47,6 @@ jobs:
       run: |
         python -m pip install -U pip
         pip install pre-commit
-        # pip install .[test]
     - name: Lint with pre-commit
       run: |
         pre-commit run --all-files


### PR DESCRIPTION
Technically Python 3.7 is EOL, so we can remove it at any point, but let's keep it until it starts to cause trouble. In any case, we probably want to keep the tested versions and the `requires-python` versions in sync.