### PR TITLE
Fix ASDF error in ZCV module

### DIFF
--- a/abacusnbody/data/asdf.py
+++ b/abacusnbody/data/asdf.py
@@ -17,11 +17,6 @@ import numpy as np
 from asdf.extension import Compressor, Extension
 
 
-def _monkey_patch(*args,**kwargs):
-    raise Exception("Please use abacusnbody.data.asdf.set_nthreads(nthreads)")
-
-asdf.compression.set_decompression_options = _monkey_patch
-
 def set_nthreads(nthreads):
     blosc.set_nthreads(nthreads)
 

--- a/abacusnbody/data/compaso_halo_catalog.py
+++ b/abacusnbody/data/compaso_halo_catalog.py
@@ -20,17 +20,21 @@ from os.path import join as pjoin
 from pathlib import PurePath
 
 import asdf
-import asdf.compression
 import astropy.table
 import numba as nb
 import numpy as np
 from astropy.table import Table
 
+try:
+    import asdf._compression as asdf_compression
+except ImportError:
+    import asdf.compression as asdf_compression
+
 from . import asdf as _asdf
 from . import bitpacked
 
 try:
-    asdf.compression.validate('blsc')
+    asdf_compression.validate('blsc')
 except Exception as e:
     raise Exception("Abacus ASDF extension not properly loaded! Try reinstalling abacusutils, or updating ASDF: `pip install asdf>=2.8`") from e
 

--- a/abacusnbody/data/pipe_asdf.py
+++ b/abacusnbody/data/pipe_asdf.py
@@ -86,11 +86,15 @@ from os.path import isfile
 from timeit import default_timer as timer
 
 import asdf
-import asdf.compression
 import numpy as np
 
 try:
-    asdf.compression.validate('blsc')
+    import asdf._compression as asdf_compression
+except ImportError:
+    import asdf.compression as asdf_compression
+
+try:
+    asdf_compression.validate('blsc')
 except Exception as e:
     raise Exception("Abacus ASDF extension not properly loaded! Try reinstalling abacusutils, or updating ASDF: `pip install asdf>=2.8`") from e
 

--- a/abacusnbody/data/read_abacus.py
+++ b/abacusnbody/data/read_abacus.py
@@ -71,9 +71,14 @@ def read_asdf(fn, load=None, colname=None, dtype=np.float32, verbose=True, **kwa
     '''
 
     import asdf
-    import asdf.compression
+
     try:
-        asdf.compression.validate('blsc')
+        import asdf._compression as asdf_compression
+    except ImportError:
+        import asdf.compression as asdf_compression
+
+    try:
+        asdf_compression.validate('blsc')
     except Exception as e:
         raise Exception("Abacus ASDF extension not properly loaded! \
                         Try reinstalling abacusutils: `pip install 'abacusutils>=1'`, \

--- a/abacusnbody/hod/zcv/advect_fields.py
+++ b/abacusnbody/hod/zcv/advect_fields.py
@@ -262,8 +262,8 @@ def main(path2config, want_rsd=False, alt_simname=None, save_3D_power=False, onl
             print("Computing cross-correlation of", keynames[i], keynames[j])
 
             # load field
-            field_fft_i = asdf.open(fields_fft_fn[i])['data']
-            field_fft_j = asdf.open(fields_fft_fn[j])['data']
+            field_fft_i = asdf.open(fields_fft_fn[i], lazy_load=False)['data']
+            field_fft_j = asdf.open(fields_fft_fn[j], lazy_load=False)['data']
 
             if save_3D_power:
                 power_ij_fn = Path(save_z_dir) / f"power{rsd_str}_{keynames[i]}_{keynames[j]}_nmesh{nmesh:d}.asdf"
@@ -295,7 +295,7 @@ def main(path2config, want_rsd=False, alt_simname=None, save_3D_power=False, onl
                 P['binned_poles'] *= field_D[i]*field_D[j]
                 pk_auto.append(P['power'])
                 pk_ij_dict[f'P_kmu_{keynames[i]}_{keynames[j]}'] = P['power']
-                pk_ij_dict[f'N_kmu_{keynames[i]}_{keynames[j]}'] = P['N_modes']
+                pk_ij_dict[f'N_kmu_{keynames[i]}_{keynames[j]}'] = P['N_mode']
                 pk_ij_dict[f'P_ell_{keynames[i]}_{keynames[j]}'] = P['binned_poles']
                 pk_ij_dict[f'N_ell_{keynames[i]}_{keynames[j]}'] = P['N_mode_poles']
                 del field_fft_i, field_fft_j; gc.collect() # noqa: E702


### PR DESCRIPTION
Fixes `OSError: Attempt to read block data from missing block` in the ZCV module, maybe caused by trying to load an array after the corresponding `AsdfFile` had been garbage collected(?).

Also adds support for ASDF 3.1.0, which renamed `asdf.compression` to `asdf._compression`.

I want to think a bit more generally about how we're loading arrays from ASDF files before we merge this. I think we're not doing it safely in many cases (e.g. not using context managers), but I'm also not exactly sure what ASDF guarantees about object lifetimes. There's also the related question of how to ensure that arrays in the tree that we reference are actually getting loaded before the file handle closes. I've opened https://github.com/asdf-format/asdf/discussions/1764 to ask about this.