### PR TITLE
ci: drop py37, add py312

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,8 @@ name: Tests
 
 on:
   push:
+    branches:
+      - main
   pull_request:
   schedule:
     # Run weekly, Friday at 7:15 EST.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,17 +76,11 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install dependencies
-      run: |
-        python -m pip install -U pip
-        pip install numpy
-        pip install 'setuptools' 'wheel' 'numpy>=1.19.0' 'Cython>=0.29.21,<3'  # for classy
-        pip install --no-build-isolation classy
-
     - name: Install package from source
       if: ${{ env.PUBLISH != 'true' }}
       run: |
-        pip install -U .[test]
+        pip install -U pip
+        pip install -vU .[test]
         make -C pipe_asdf
 
     - name: Fetch wheel

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,6 @@ repos:
         # TODO: turning off line length check
         # When ruff formatting is available, use that to auto-fix
         args: [--fix, --ignore=E501]
-      - id: ruff-format
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
     hooks:
@@ -29,6 +28,7 @@ repos:
       - id: check-yaml
       - id: check-added-large-files
         args: ['--maxkb=20000']
+      - id: check-ast
       - id: check-executables-have-shebangs
       - id: check-merge-conflict
       - id: check-shebang-scripts-are-executable

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
       - id: ruff
         # TODO: turning off line length check
         # When ruff formatting is available, use that to auto-fix
-        args: [--fix, --exit-non-zero-on-fix, --ignore=E501]
+        args: [--fix, --ignore=E501]
       - id: ruff-format
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0


### PR DESCRIPTION
Python 3.12 requires Cython 3, which previously classy didn't support. But maybe now it does?