### PR TITLE
Update prepare_sim.py

### DIFF
--- a/abacusnbody/hod/prepare_sim.py
+++ b/abacusnbody/hod/prepare_sim.py
@@ -528,7 +528,7 @@ def prepare_slab(
 
             if len(index_bounds) > 0:
                 # factor of rands to generate
-                rand = 10
+                rand = 100 # to ensure 12 times more randoms than haloes in the octant.
                 rand_N = allpos.shape[0] * rand
 
                 # generate randoms in L shape
@@ -591,7 +591,7 @@ def prepare_slab(
         gc.collect()
 
         if halo_lc and len(index_bounds) > 0:
-            Menv[index_bounds] *= rand_norm
+            Menv[index_bounds] /= rand_norm 
 
         halos['fenv_rank'] = calc_fenv_opt(Menv, mbins, allmasses)
 

--- a/abacusnbody/hod/prepare_sim.py
+++ b/abacusnbody/hod/prepare_sim.py
@@ -528,7 +528,7 @@ def prepare_slab(
 
             if len(index_bounds) > 0:
                 # factor of rands to generate
-                rand = 100 # to ensure 12 times more randoms than haloes in the octant.
+                rand = 100  # to ensure 12 times more randoms than haloes in the octant.
                 rand_N = allpos.shape[0] * rand
 
                 # generate randoms in L shape
@@ -591,7 +591,7 @@ def prepare_slab(
         gc.collect()
 
         if halo_lc and len(index_bounds) > 0:
-            Menv[index_bounds] /= rand_norm 
+            Menv[index_bounds] /= rand_norm
 
         halos['fenv_rank'] = calc_fenv_opt(Menv, mbins, allmasses)
 


### PR DESCRIPTION
Hello 
I have found an issue with using the assembly bias parameters. Depending on the Bcent or Bsat value, I found pronounced over/under densities at the edges (in ra, dec and redshift) of the individual light cones. The issue is in the prepare_sim.py file, where the Menv are corrected at the boundaries of the light cones. In particular, line 445 multiplies instead of being divided by rand_norm. It needs to be divided because rand_norm is the number of randoms divided by the expected number of randoms, so the more volume is missing, the smaller rand_norm gets. To correct the Menv calculations, they must be divided by rand_norm to upweight the regions with a smaller effective volume.
 
As a minor improvement, I increased the number of randoms by ten to 100, as after cutting the randoms to the octant, only 1/8 of the randoms survived. Thus, originally, only 1.25 more randoms than haloes were used. 

Please let me know if these corrections are correct or if I am misunderstanding them. With these corrections, the over/under densities at the edges almost disappeared.   

All the best
Pierre