### PR TITLE
Add `prepare_sim.Nthread_per_load` parameter

### DIFF
--- a/abacusnbody/hod/prepare_sim.py
+++ b/abacusnbody/hod/prepare_sim.py
@@ -1094,9 +1094,16 @@ def main(
     else:
         shearmark = None
     # N_dim = config['HOD_params']['Ndim']
-    nthread = int(
-        np.floor(multiprocessing.cpu_count() / config['prepare_sim']['Nparallel_load'])
-    )
+    nthread = config['prepare_sim'].get('Nthread_per_load', 'auto')
+    if nthread == 'auto':
+        nthread = int(
+            np.floor(
+                len(os.sched_getaffinity(0)) / config['prepare_sim']['Nparallel_load']
+            )
+        )
+        print(f'prepare_sim inferred Nthread_per_load = {nthread}')
+    else:
+        nthread = int(nthread)
 
     p = multiprocessing.Pool(config['prepare_sim']['Nparallel_load'])
     p.starmap(

--- a/abacusnbody/hod/prepare_sim.py
+++ b/abacusnbody/hod/prepare_sim.py
@@ -1096,10 +1096,8 @@ def main(
     # N_dim = config['HOD_params']['Ndim']
     nthread = config['prepare_sim'].get('Nthread_per_load', 'auto')
     if nthread == 'auto':
-        nthread = int(
-            np.floor(
-                len(os.sched_getaffinity(0)) / config['prepare_sim']['Nparallel_load']
-            )
+        nthread = (
+            len(os.sched_getaffinity(0)) // config['prepare_sim']['Nparallel_load']
         )
         print(f'prepare_sim inferred Nthread_per_load = {nthread}')
     else:

--- a/scripts/hod/config/abacus_hod.yaml
+++ b/scripts/hod/config/abacus_hod.yaml
@@ -13,7 +13,8 @@ sim_params:
     cleaned_halos: True                                                     # load cleaned halos?
 
 prepare_sim:
-    Nparallel_load: 5                                                          # number of thread for organizing simulation outputs (prepare_sim)
+    Nparallel_load: 5                                          # number of processes. peak memory usage will increase by this factor.
+    Nthread_per_load: 'auto'                                   # number of threads per process (auto uses the affinity mask)
 
 # HOD parameters
 HOD_params:

--- a/scripts/hod/config/lc_hod.yaml
+++ b/scripts/hod/config/lc_hod.yaml
@@ -14,6 +14,7 @@ sim_params:
 
 prepare_sim:
     Nparallel_load: 1 # not sure if this makes a difference since we have a single slab
+    Nthread_per_load: 'auto'
 
 # HOD parameters
 HOD_params:


### PR DESCRIPTION
This adds `Nthread_per_load` as a user-configurable parameter for `prepare_sim`. This is used by Numba and the tree searches as the number of threads inside each of the `Nparallel_load` `prepare_sim` processes. The default is `'auto'` which will use `Nthread_per_load = len(os.sched_getaffinity(0)) // Nparallel_load`. When setting this manually, one should make sure that `Nparallel_load * Nthread_per_load` doesn't exceed the number of total CPUs!

Previously, we were using `multiprocessing.cpu_count()` instead of `os.sched_getaffinity(0)`, which will return too many cores when the affinity mask is in use, e.g., on shared Slurm nodes. Neither of these will give the desired answer when containers/cgroups are being used (e.g. on Binder), so in that case, the user needs to set the correct value.