### PR TITLE
changing normalization to standard

### DIFF
--- a/abacusnbody/analysis/power_spectrum.py
+++ b/abacusnbody/analysis/power_spectrum.py
@@ -852,6 +852,7 @@ def get_field(
             cic_serial(pos, field, Lbox, weights=w)
     else:
         raise ValueError(f'Unknown pasting method: {paste}')
+    """
     if (
         w is None
     ):  # in the zcv code the weights are already normalized, so don't normalize here
@@ -859,6 +860,8 @@ def get_field(
         # same as passing "Value" to nbodykit (1+delta)(x) V(x)
         # leads to -1 in the complex field
         normalize_field(field, inplace=True, tot_weight=len(pos), nthread=nthread)
+    """
+    normalize_field(field, inplace=True, tot_weight=len(pos), nthread=nthread)
     return field
 
 


### PR DESCRIPTION
It seems like the only place that because the only case in which the normalization matters is when the number of pcles is different from the number of grid points, the ZCV method is safe (tested Pk but not Xi), so the normalization can be fixed with a single line change.

I will also try to add to this the correction to lc env calculation for AbacusHOD