### PR TITLE
ci: add python 3.12 and enhance `NUMBA_DISABLE_JIT` support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,7 +66,7 @@ jobs:
         }}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4
@@ -81,8 +81,8 @@ jobs:
     - name: Pre-install dependencies
       run: |
         pip install -vU pip
-        pip install -vU setuptools wheel Cython scipy 'numpy<2'  # for corrfunc, classy
-        pip install -vU --no-build-isolation corrfunc classy
+        pip install -vU setuptools wheel Cython 'numpy<2'  # for classy
+        pip install -vU --no-build-isolation classy
 
     - name: Install package from source
       if: ${{ env.PUBLISH != 'true' }}

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Changelog
 Enhancements
 ~~~~~~~~~~~~
 - ``hod.prepare_sim``: detect and report when a ``prepare_slab`` subprocess fails [#151]
+- ci: add python 3.12 and enhance ``NUMBA_DISABLE_JIT`` support [#153]
 
 2.0.1 (2024-03-01)
 ------------------

--- a/tests/common.py
+++ b/tests/common.py
@@ -4,13 +4,12 @@ Common resources for the tests.
 
 import numbers
 
-import numpy as np
-
+import numpy.testing as npt
 
 def check_close(arr1, arr2):
     """Checks exact equality for int arrays, and np.isclose for floats"""
     if issubclass(arr1.dtype.type, numbers.Integral):
         assert issubclass(arr2.dtype.type, numbers.Integral)
-        return np.all(arr1 == arr2)
+        npt.assert_array_equal(arr1, arr2)
     else:
-        return np.allclose(arr1, arr2)
+        npt.assert_allclose(arr1, arr2)

--- a/tests/common.py
+++ b/tests/common.py
@@ -6,6 +6,7 @@ import numbers
 
 import numpy.testing as npt
 
+
 def check_close(arr1, arr2):
     """Checks exact equality for int arrays, and np.isclose for floats"""
     if issubclass(arr1.dtype.type, numbers.Integral):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -38,7 +38,7 @@ def test_halos_unclean(tmp_path):
 
     halos = cat.halos
     for col in ref.colnames:
-        assert check_close(ref[col], halos[col])
+        check_close(ref[col], halos[col])
 
     assert halos.meta == ref.meta
 
@@ -60,7 +60,7 @@ def test_halos_clean(tmp_path):
 
     halos = cat.halos
     for col in ref.colnames:
-        assert check_close(ref[col], halos[col])
+        check_close(ref[col], halos[col])
 
     # all haloindex values should point to this slab
     assert np.all(
@@ -113,7 +113,7 @@ def test_subsamples_unclean(tmp_path):
 
     ss = cat.subsamples
     for col in ref.colnames:
-        assert check_close(ref[col], ss[col])
+        check_close(ref[col], ss[col])
 
     assert cat.subsamples.meta == ref.meta
 
@@ -136,7 +136,7 @@ def test_subsamples_clean(tmp_path):
 
     ss = cat.subsamples
     for col in ref.colnames:
-        assert check_close(ref[col], ss[col])
+        check_close(ref[col], ss[col])
 
     # total number of particles in ref should be equal to the sum total of npout{AB} in EXAMPLE_SIM
     assert len(ref) == np.sum(cat.halos['npoutA']) + np.sum(cat.halos['npoutB'])
@@ -295,12 +295,12 @@ def test_halo_lc():
     ref = Table.read(HALO_LC_CAT)
     halos = cat.halos
     for col in ref.colnames:
-        assert check_close(ref[col], halos[col])
+        check_close(ref[col], halos[col])
     assert halos.meta == ref.meta
 
     ref = Table.read(HALO_LC_SUBSAMPLES)
     ss = cat.subsamples
     for col in ref.colnames:
-        assert check_close(ref[col], ss[col])
+        check_close(ref[col], ss[col])
 
     assert ss.meta == ref.meta

--- a/tests/test_hod.py
+++ b/tests/test_hod.py
@@ -95,14 +95,14 @@ def test_hod(tmp_path, reference_mode=False):
         for i in range(len(newhalos)):
             print(newhalos[i], temphalos[i])
             for j in range(len(newhalos[i])):
-                assert check_close(newhalos[i][j], temphalos[i][j])
+                check_close(newhalos[i][j], temphalos[i][j])
         newparticles = h5py.File(
             savedir + '/particles_xcom_2_seed600_abacushod_oldfenv_MT_new.h5', 'r'
         )['particles']
         tempparticles = h5py.File(EXAMPLE_SUBSAMPLE_PARTS, 'r')['particles']
         for i in range(len(newparticles)):
             for j in range(len(newparticles[i])):
-                assert check_close(newparticles[i][j], tempparticles[i][j])
+                check_close(newparticles[i][j], tempparticles[i][j])
 
         # additional parameter choices
         want_rsd = HOD_params['want_rsd']
@@ -125,7 +125,7 @@ def test_hod(tmp_path, reference_mode=False):
         data = ascii.read(EXAMPLE_LRGS)
         data1 = ascii.read(savedir_gal)
         for ekey in data.keys():
-            assert check_close(data[ekey], data1[ekey])
+            check_close(data[ekey], data1[ekey])
 
         savedir_gal = (
             config['sim_params']['output_dir']
@@ -138,7 +138,7 @@ def test_hod(tmp_path, reference_mode=False):
         data = ascii.read(EXAMPLE_ELGS)
         data1 = ascii.read(savedir_gal)
         for ekey in data.keys():
-            assert check_close(data[ekey], data1[ekey])
+            check_close(data[ekey], data1[ekey])
 
         # smoke test for zcv
         config['sim_params']['sim_name'] = (

--- a/tests/test_lc_hod.py
+++ b/tests/test_lc_hod.py
@@ -96,14 +96,14 @@ def test_hod(tmp_path, reference_mode=False):
         temphalos = h5py.File(EXAMPLE_SUBSAMPLE_HALOS, 'r')['halos']
         for i in range(len(newhalos)):
             for j in range(len(newhalos[i])):
-                assert check_close(newhalos[i][j], temphalos[i][j])
+                check_close(newhalos[i][j], temphalos[i][j])
         newparticles = h5py.File(
             savedir + '/particles_xcom_0_seed600_abacushod_oldfenv_MT_new.h5', 'r'
         )['particles']
         tempparticles = h5py.File(EXAMPLE_SUBSAMPLE_PARTS, 'r')['particles']
         for i in range(len(newparticles)):
             for j in range(len(newparticles[i])):
-                assert check_close(newparticles[i][j], tempparticles[i][j])
+                check_close(newparticles[i][j], tempparticles[i][j])
 
         # additional parameter choices
         want_rsd = HOD_params['want_rsd']
@@ -129,7 +129,7 @@ def test_hod(tmp_path, reference_mode=False):
         data = ascii.read(EXAMPLE_LRGS)
         data1 = ascii.read(savedir_gal)
         for ekey in data.keys():
-            assert check_close(data[ekey], data1[ekey])
+            check_close(data[ekey], data1[ekey])
 
         savedir_gal = (
             config['sim_params']['output_dir']
@@ -142,7 +142,7 @@ def test_hod(tmp_path, reference_mode=False):
         data = ascii.read(EXAMPLE_ELGS)
         data1 = ascii.read(savedir_gal)
         for ekey in data.keys():
-            assert check_close(data[ekey], data1[ekey])
+            check_close(data[ekey], data1[ekey])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Take 2 of #135; hopefully upstream dependencies all support Python 3.12 now.

It looks like classy doesn't support NumPy 2 yet which is unfortunate, but everything else seems to. For now, we won't impose a version maximum on abacusutils because classy is only needed for the ZCV module.