### PR TITLE
compaso: add passthrough support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ Enhancements
 - ci: add python 3.12 and enhance ``NUMBA_DISABLE_JIT`` support [#153]
 - Improve CompaSO subsample loading [#154]
 - deprecate ``asdf.open(copy_arrays=True)`` in favor of ``asdf.open(memmap=False)`` [#157]
+- compaso: add passthrough support [#162]
 
 2.0.1 (2024-03-01)
 ------------------


### PR DESCRIPTION
For the halo light cone catalogs in the Backlight project, we're doing halo finding on the time slices, then interpolating them onto the light cone with merger trees. Many time slice halos won't appear in the light cone, so there's no point in saving them. When we create the "squashed" catalogs that remove unused halos, we don't want to unpack all the columns, we want them to stay in their original format (e.g. we don't want to unpack rvint subsamples, because the floats won't compress as well). But we still want to load things through the `CompaSOHaloCatalog` interface, because it does all sorts of non-trivial merging of the uncleaned and cleaned halo info and subsamples, as well as row-based filtering, which we're going to use to get rid of unused halos.

This PR adds a `passthrough` bool argument to the CHC constructor to load halo info and subsamples without unpacking them. This effectively provides a way to get the raw data through CHC. Most users won't need this unless they're writing a pipeline where they want to defer the unpacking of the data to a later stage (often at the end-user stage, as CHC usually does).