### PR TITLE
Fix `read_asdf` on rv data

### DIFF
--- a/abacusnbody/data/bitpacked.py
+++ b/abacusnbody/data/bitpacked.py
@@ -64,8 +64,10 @@ def unpack_rvint(intdata, boxsize, float_dtype=np.float32, posout=None, velout=N
     elif posout is False:
         _posout = None
     else:
+        # In NumPy >= 2.1, we can use arr.reshape(..., copy=False).
+        # This is a workaround for earlier NumPy.
         _posout = posout.view()
-        _posout.shape = -1  # enforces no copy
+        _posout.shape = (-1, 3)
 
     if velout is None:
         _velout = np.empty((N, 3), dtype=float_dtype)
@@ -73,7 +75,7 @@ def unpack_rvint(intdata, boxsize, float_dtype=np.float32, posout=None, velout=N
         _velout = None
     else:
         _velout = velout.view()
-        _velout.shape = -1  # enforces no copy
+        _velout.shape = (-1, 3)
 
     _unpack_rvint(intdata, boxsize, _posout, _velout)
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -7,7 +7,7 @@ import numbers
 import numpy.testing as npt
 
 
-def check_close(arr1, arr2):
+def assert_close(arr1, arr2):
     """Checks exact equality for int arrays, and np.isclose for floats"""
     if issubclass(arr1.dtype.type, numbers.Integral):
         assert issubclass(arr2.dtype.type, numbers.Integral)

--- a/tests/ref_data/test_read_asdf.asdf
+++ b/tests/ref_data/test_read_asdf.asdf
@@ -1,0 +1,544 @@
+#ASDF 1.0.0
+#ASDF_STANDARD 1.5.0
+%YAML 1.1
+%TAG ! tag:stsci.edu:asdf/
+--- !core/asdf-1.1.0
+asdf_library: !core/software-1.0.0 {author: The ASDF Developers, homepage: 'http://github.com/asdf-format/asdf',
+  name: asdf, version: 3.5.0}
+history:
+  extensions:
+  - !core/extension_metadata-1.0.0
+    extension_class: abacusnbody.data.asdf.AbacusExtension
+    extension_uri: asdf://abacusnbody.org/extensions/abacus-0.0.1
+    software: !core/software-1.0.0 {name: abacusutils, version: 2.0.2.dev51+ga743214}
+    supported_compression: [blsc]
+  - !core/extension_metadata-1.0.0
+    extension_class: asdf.extension._manifest.ManifestExtension
+    extension_uri: asdf://asdf-format.org/core/extensions/core-1.5.0
+    manifest_software: !core/software-1.0.0 {name: asdf_standard, version: 1.1.1}
+    software: !core/software-1.0.0 {name: asdf-astropy, version: 0.6.1}
+  - !core/extension_metadata-1.0.0
+    extension_class: asdf.extension._manifest.ManifestExtension
+    extension_uri: asdf://astropy.org/astropy/extensions/astropy-1.1.0
+    software: !core/software-1.0.0 {name: asdf-astropy, version: 0.6.1}
+pid_data: !<tag:astropy.org:astropy/table/table-1.1.0>
+  colnames: [aux, pid, lagr_pos, lagr_idx, tagged, density]
+  columns:
+  - !core/column-1.0.0
+    data: !core/ndarray-1.0.0
+      source: 2
+      datatype: uint64
+      byteorder: little
+      shape: [1646]
+    name: aux
+  - !core/column-1.0.0
+    data: !core/ndarray-1.0.0
+      source: 3
+      datatype: int64
+      byteorder: little
+      shape: [1646]
+    name: pid
+  - !core/column-1.0.0
+    data: !core/ndarray-1.0.0
+      source: 4
+      datatype: float32
+      byteorder: little
+      shape: [1646, 3]
+    name: lagr_pos
+  - !core/column-1.0.0
+    data: !core/ndarray-1.0.0
+      source: 5
+      datatype: int16
+      byteorder: little
+      shape: [1646, 3]
+    name: lagr_idx
+  - !core/column-1.0.0
+    data: !core/ndarray-1.0.0
+      source: 6
+      datatype: uint8
+      byteorder: big
+      shape: [1646]
+    name: tagged
+  - !core/column-1.0.0
+    data: !core/ndarray-1.0.0
+      source: 7
+      datatype: float32
+      byteorder: little
+      shape: [1646]
+    name: density
+  meta:
+    AllowGroupFinding: 1
+    BackupDirectory: /mnt/ceph/users/lgarrison//Mini_N64_L32
+    BackupStepInterval: -1
+    BoxSize: 32.0
+    BoxSizeHMpc: 32.0
+    BoxSizeMpc: 47.50593824228029
+    CPD: 15
+    CodeVersion: 210efc5b64ece6cff9618aa2fff7826da536b691
+    Conv_IOCores: 0
+    Conv_IOMode: normal
+    Conv_OMP_NUM_THREADS: 0
+    Conv_OMP_PLACES: '{0}:40'
+    Conv_OMP_PROC_BIND: close
+    CoordinateDistanceHMpc: 2.7958e-11
+    DeltaEtaDrift: 0.001765068836306227
+    DeltaRedshift: 0.001764249459376
+    DeltaScaleFactor: 0.001761142364911
+    DeltaTime: 0.001761959818535
+    DensityKernelRad: 0.4
+    DensityKernelRad2: 3.90625e-05
+    DerivativeExpansionRadius: 8
+    DerivativesDirectory: /dev/shm/lgarrison/Derivatives
+    DirectBPD: 2
+    Do2LPTVelocityRereading: 0
+    DoublePrecision: 0
+    FinalRedshift: 0.0
+    FirstHalfEtaKick: 0.0008821452739717905
+    FoFLinkingLength: [0.25, 0.25, 0.25]
+    FullStepNumber: 580
+    GPUQueueAssignments: [0, 0, 1, 1]
+    GPUThreadCoreStart: [36, 38, 37, 39]
+    GroupDirectory: /mnt/ceph/users/lgarrison//Mini_N64_L32/group
+    GroupRadius: 3
+    Growth: 0.78841783554687
+    Growth_on_a_n: 0.78841783554687
+    H0: 67.36
+    Htime: 0.950822217525797
+    HubbleNow: 1.0
+    HubbleTimeGyr: 14.516330166270784
+    HubbleTimeHGyr: 9.7782
+    ICFormat: RVZel
+    ICPositionRange: 32
+    ICVelocity2Displacement: 1.0
+    IOCores: 35
+    InitialConditionsDirectory: /mnt/ceph/users/lgarrison//Mini_N64_L32/ic
+    InitialRedshift: 99.0
+    L0DensityThreshold: 110.59151887893677
+    L1OutputRedshifts: [2, 1, 0.5, 0.0]
+    L1Output_dlna: -1
+    LPTStepNumber: 0
+    LagrangianPTOrder: 2
+    LastHalfEtaKick: 0.0008813681400008377
+    LightConeDirectory: /mnt/ceph/users/lgarrison//Mini_N64_L32/lightcone
+    LightConeOrigins: [-15.0, -15.0, -15.0, -15.0, -15.0, -47.0, -15.0, -47.0, -15.0]
+    LogDirectory: /mnt/ceph/users/lgarrison//Mini_N64_L32/log
+    MAXRAMMB: 200000
+    MachineName: workergpu19
+    MicrostepTimeStep: 0
+    MinL1HaloNP: 35
+    MultipoleDirectory: /dev/shm/lgarrison/Mini_N64_L32/multipole
+    MunmapThreadCore: 35
+    NGPUThreadCores: 1
+    NLightCones: 3
+    NP: 262144
+    NearFieldRadius: 2
+    NodeRank: 0
+    NodeSize: 0
+    NumSlabsInsertList: 2
+    NumSlabsInsertListIC: 15
+    OMP_NUM_THREADS: 35
+    OMP_PLACES: '{0}:18:2,{1}:17:2'
+    OMP_PROC_BIND: spread
+    OmegaNow_DE: 0.684808
+    OmegaNow_K: 0.0
+    OmegaNow_m: 0.315192
+    Omega_DE: 0.684808
+    Omega_K: 0.0
+    Omega_M: 0.315192
+    Omega_Smooth: 0.00142
+    Order: 8
+    OutputDirectory: /mnt/ceph/users/lgarrison//Mini_N64_L32
+    OutputFormat: Pack9
+    OutputFormatVersion: v2.2
+    OutputType: GroupOutput
+    ParameterFileName: abacus.par
+    ParticleMassHMsun: 10882397390.0
+    ParticleMassMsun: 16155578073.04038
+    ParticleSubsampleA: 0.03
+    ParticleSubsampleB: 0.07
+    Pipeline: singlestep
+    PowerSpectrumN1d: 256
+    PowerSpectrumStepInterval: -1
+    ProperSoftening: 1
+    RamDisk: 1
+    Redshift: 0.0
+    RunTime: Fri Jul 24 15:24:21 2020
+    SODensity: [200, 800]
+    SODensityL1: 368.63839626312256
+    SODensityL2: 1474.5535850524902
+    SO_EvolvingThreshold: 1
+    SO_alpha_eligible: 0.8
+    ScaleFactor: 1.0
+    ScaleFactorHalf: 0.9991192245681288
+    SimName: Mini_N64_L32
+    SofteningLength: 0.012500000000000002
+    SofteningLengthNow: 0.01252205311824221
+    SofteningLengthNowInternal: 0.02698715321884206
+    SofteningMax: 0.15000000000000002
+    SofteningType: single_spline
+    StateIOMode: normal
+    TaylorDirectory: /dev/shm/lgarrison/Mini_N64_L32/taylor
+    Time: 0.950822217525797
+    TimeSliceRedshifts: [2, 1, 0.5, 0.0]
+    TimeStepAccel: 0.25
+    TimeStepDlna: 0.03
+    VelZSpace_to_Canonical: 1.0
+    VelZSpace_to_kms: 3200.0
+    WorkingDirectory: /dev/shm/lgarrison/Mini_N64_L32
+    ZD_NumBlock: 2
+    ZD_PLT_filename: /mnt/home/lgarrison/abacus/external/zeldovich-PLT/eigmodes128
+    ZD_PLT_target_z: 12.0
+    ZD_Pk_file_redshift: 1.0
+    ZD_Pk_filename: /mnt/home/lgarrison/abacus/external/AbacusSummit/Cosmologies/abacus_cosm000/CLASS_power
+    ZD_Pk_norm: 8.0
+    ZD_Pk_scale: 1.0
+    ZD_Pk_sigma_ratio: 0.02113950155394198
+    ZD_Pk_smooth: 0.0
+    ZD_Seed: 12321
+    ZD_Version: 2
+    ZD_f_cluster: 0.9954948095129318
+    ZD_k_cutoff: 1.0
+    ZD_qPLT: 1
+    ZD_qPLT_rescale: 1
+    ZeldovichDirectory: /mnt/home/lgarrison/abacus/external/zeldovich-PLT
+    etaD: -4.054275577372243
+    etaK: 3.239379512725195
+    f_growth: 0.525827390791488
+    fsmooth: 0.004505190487068
+    hMpc: 1
+    ppd: 64.0
+    w: -1.0
+    w0: -1.0
+    wa: 0.0
+  qtable: false
+rv_data: !<tag:astropy.org:astropy/table/table-1.1.0>
+  colnames: [pos, vel]
+  columns:
+  - !core/column-1.0.0
+    data: !core/ndarray-1.0.0
+      source: 0
+      datatype: float32
+      byteorder: little
+      shape: [1646, 3]
+    name: pos
+  - !core/column-1.0.0
+    data: !core/ndarray-1.0.0
+      source: 1
+      datatype: float32
+      byteorder: little
+      shape: [1646, 3]
+    name: vel
+  meta:
+    AllowGroupFinding: 1
+    BackupDirectory: /mnt/ceph/users/lgarrison//Mini_N64_L32
+    BackupStepInterval: -1
+    BoxSize: 32.0
+    BoxSizeHMpc: 32.0
+    BoxSizeMpc: 47.50593824228029
+    CPD: 15
+    CodeVersion: 210efc5b64ece6cff9618aa2fff7826da536b691
+    Conv_IOCores: 0
+    Conv_IOMode: normal
+    Conv_OMP_NUM_THREADS: 0
+    Conv_OMP_PLACES: '{0}:40'
+    Conv_OMP_PROC_BIND: close
+    CoordinateDistanceHMpc: 2.7958e-11
+    DeltaEtaDrift: 0.001765068836306227
+    DeltaRedshift: 0.001764249459376
+    DeltaScaleFactor: 0.001761142364911
+    DeltaTime: 0.001761959818535
+    DensityKernelRad: 0.4
+    DensityKernelRad2: 3.90625e-05
+    DerivativeExpansionRadius: 8
+    DerivativesDirectory: /dev/shm/lgarrison/Derivatives
+    DirectBPD: 2
+    Do2LPTVelocityRereading: 0
+    DoublePrecision: 0
+    FinalRedshift: 0.0
+    FirstHalfEtaKick: 0.0008821452739717905
+    FoFLinkingLength: [0.25, 0.25, 0.25]
+    FullStepNumber: 580
+    GPUQueueAssignments: [0, 0, 1, 1]
+    GPUThreadCoreStart: [36, 38, 37, 39]
+    GroupDirectory: /mnt/ceph/users/lgarrison//Mini_N64_L32/group
+    GroupRadius: 3
+    Growth: 0.78841783554687
+    Growth_on_a_n: 0.78841783554687
+    H0: 67.36
+    Htime: 0.950822217525797
+    HubbleNow: 1.0
+    HubbleTimeGyr: 14.516330166270784
+    HubbleTimeHGyr: 9.7782
+    ICFormat: RVZel
+    ICPositionRange: 32
+    ICVelocity2Displacement: 1.0
+    IOCores: 35
+    InitialConditionsDirectory: /mnt/ceph/users/lgarrison//Mini_N64_L32/ic
+    InitialRedshift: 99.0
+    L0DensityThreshold: 110.59151887893677
+    L1OutputRedshifts: [2, 1, 0.5, 0.0]
+    L1Output_dlna: -1
+    LPTStepNumber: 0
+    LagrangianPTOrder: 2
+    LastHalfEtaKick: 0.0008813681400008377
+    LightConeDirectory: /mnt/ceph/users/lgarrison//Mini_N64_L32/lightcone
+    LightConeOrigins: [-15.0, -15.0, -15.0, -15.0, -15.0, -47.0, -15.0, -47.0, -15.0]
+    LogDirectory: /mnt/ceph/users/lgarrison//Mini_N64_L32/log
+    MAXRAMMB: 200000
+    MachineName: workergpu19
+    MicrostepTimeStep: 0
+    MinL1HaloNP: 35
+    MultipoleDirectory: /dev/shm/lgarrison/Mini_N64_L32/multipole
+    MunmapThreadCore: 35
+    NGPUThreadCores: 1
+    NLightCones: 3
+    NP: 262144
+    NearFieldRadius: 2
+    NodeRank: 0
+    NodeSize: 0
+    NumSlabsInsertList: 2
+    NumSlabsInsertListIC: 15
+    OMP_NUM_THREADS: 35
+    OMP_PLACES: '{0}:18:2,{1}:17:2'
+    OMP_PROC_BIND: spread
+    OmegaNow_DE: 0.684808
+    OmegaNow_K: 0.0
+    OmegaNow_m: 0.315192
+    Omega_DE: 0.684808
+    Omega_K: 0.0
+    Omega_M: 0.315192
+    Omega_Smooth: 0.00142
+    Order: 8
+    OutputDirectory: /mnt/ceph/users/lgarrison//Mini_N64_L32
+    OutputFormat: Pack9
+    OutputFormatVersion: v2.2
+    OutputType: GroupOutput
+    ParameterFileName: abacus.par
+    ParticleMassHMsun: 10882397390.0
+    ParticleMassMsun: 16155578073.04038
+    ParticleSubsampleA: 0.03
+    ParticleSubsampleB: 0.07
+    Pipeline: singlestep
+    PowerSpectrumN1d: 256
+    PowerSpectrumStepInterval: -1
+    ProperSoftening: 1
+    RamDisk: 1
+    Redshift: 0.0
+    RunTime: Fri Jul 24 15:24:21 2020
+    SODensity: [200, 800]
+    SODensityL1: 368.63839626312256
+    SODensityL2: 1474.5535850524902
+    SO_EvolvingThreshold: 1
+    SO_alpha_eligible: 0.8
+    ScaleFactor: 1.0
+    ScaleFactorHalf: 0.9991192245681288
+    SimName: Mini_N64_L32
+    SofteningLength: 0.012500000000000002
+    SofteningLengthNow: 0.01252205311824221
+    SofteningLengthNowInternal: 0.02698715321884206
+    SofteningMax: 0.15000000000000002
+    SofteningType: single_spline
+    StateIOMode: normal
+    TaylorDirectory: /dev/shm/lgarrison/Mini_N64_L32/taylor
+    Time: 0.950822217525797
+    TimeSliceRedshifts: [2, 1, 0.5, 0.0]
+    TimeStepAccel: 0.25
+    TimeStepDlna: 0.03
+    VelZSpace_to_Canonical: 1.0
+    VelZSpace_to_kms: 3200.0
+    WorkingDirectory: /dev/shm/lgarrison/Mini_N64_L32
+    ZD_NumBlock: 2
+    ZD_PLT_filename: /mnt/home/lgarrison/abacus/external/zeldovich-PLT/eigmodes128
+    ZD_PLT_target_z: 12.0
+    ZD_Pk_file_redshift: 1.0
+    ZD_Pk_filename: /mnt/home/lgarrison/abacus/external/AbacusSummit/Cosmologies/abacus_cosm000/CLASS_power
+    ZD_Pk_norm: 8.0
+    ZD_Pk_scale: 1.0
+    ZD_Pk_sigma_ratio: 0.02113950155394198
+    ZD_Pk_smooth: 0.0
+    ZD_Seed: 12321
+    ZD_Version: 2
+    ZD_f_cluster: 0.9954948095129318
+    ZD_k_cutoff: 1.0
+    ZD_qPLT: 1
+    ZD_qPLT_rescale: 1
+    ZeldovichDirectory: /mnt/home/lgarrison/abacus/external/zeldovich-PLT
+    etaD: -4.054275577372243
+    etaK: 3.239379512725195
+    f_growth: 0.525827390791488
+    fsmooth: 0.004505190487068
+    hMpc: 1
+    ppd: 64.0
+    w: -1.0
+    w0: -1.0
+    wa: 0.0
+  qtable: false
+...
+ÓBLK 0    blsc      Fœ      Fœ      M(¹ÿú÷¢Œl·¥F)¬  F˜‘(M  (M  ˜F     €F  (µ/ı`(Lµ3Òœ/p[¡Ä¨Á	
+HÀ³ŠÄc#C›òæk9“•µï°Øİ0yùyµrÛ_kkˆ” Kî7 /Sm4U G‡ª©i*$Š¾ u.J§¿|…UŠ]xÁKfï|t.ñ	Ô"fw¿‚Ş`q„Íìí|<y\]Ò³ˆiß3ÍÑN<½ô¿'ô ¥™`AmÕ²¤÷©eõ#¥~b§ëpy ıFÒI[Jzá¨a^…q ¯øz„sòƒ;7zCs;£>Ü¤rÅ‡îŸ×bË&€s¡3­_à¥…]y”9 ¿¢Ëá™ÁNá<@›+_`¹_HçğÔü®K«NâêuÌ½Qq0ä`dë11å~R21“è¤É|Sº×(ŞTõFÂù*ŠqÒvÆ ı†œ^zÃy%¤|¼°=ê&ï.‘Î3AàFP¶Nxa¶y´ú Xªc,ºÛ£0šÛ¢6‘]ĞC½*¹ƒ,ıŠÀGßID}Ë®…ru ,—Ã×®œE~¤köƒr'üšã5à~h	è‚•w9ÓrÏ¿˜n§d-#¢ùºZ­{ÕfFÎÀ‡eA¯Ã-¢zæ\’ÜO‘!Pw®É³CÀìW`åk«ÇûÖğÀ(ífˆc¡¢Œ‚›åx{î.\ãÉÍø/×"¿ ô5Æ¢cğ×Ğµ„ø\ÙjÛè:<Y,×!ÀìK²9X(ˆÏAı´®²·A8;ß£é¥„Şü«ÑÆğ˜ò¯)0÷JÒà,Pæ3V§G0’àyFA^ Ê8ÅâŞÃº.Upvo~•[ûèòy?ŞcN]zºâpFQT¶OÄÚ¸_#ƒzEéÇ?ÛKPUı ’ÚîŒp^‚c–ëz¿¯ïÙåiÙ!f·ö¼´°&ò¤óøÊó€gz	Š!×’å~ˆØ)z7YpDy»{àƒBhîèBíŞ|/!¯.o‚šø!àÑûöÔä,{Í)R®·i•©vèødŞâóĞòÕ-Ú!˜U®ZõòJ=L×ƒ#'²âæÜ“>‘¥O˜Qãx4à.hTŞ¦ğo´gp c™k˜ë»wA|£‰cãùÁ[O8«á<×æC!~²Kôui4¼p@İÜÓŒãqºÀmFäÙBÂpjyÉH¿éôú@;IŞ™£ßü3}„5³ÍB‰Cî±|¸Ã!æ˜QZÏ—:×Rå©Åäv'´¤—ìÒtœ…¤KO 8%Ğİ”BèÌ*ï#A'o‹Ö¤'ê|ñÇóÔàhuvüRE/pB¢yÌyğÍ(n÷—¢i¼fı1Íğxšİ2(+3kéoŠô†¶2õ;/&úƒ›ï7I(ù›Ô®QwÌÎ9Ç+Ó3Ğì}QÌå¢b›dÑ1I9SjUtÿØD¾à
+c‡&¹óN*‰¿óQ¦Y°ÅŞó
+Üá¤¬èXoÔ åƒ_~ı§†Ã4ùF­ÈÉá!¬ÜÁb^£:pqJ)»—À¨‰| òÊ§ÏK(ÒCXø=²5Ïõv´hÖ7r.ÉáòAD
+§ï–JÚ|c«ĞñOªÂ? ¢Ö¦0üîH+á.¥¼¯Û«œ­)£ÅÈ’³q‡Dâ¦UĞ…fJµÍ#öŒ32fYè)PÙèÅ´¿¬8§ô”¶Ÿíˆ™)„±ü„ÊİXåMF¬›<'â™†…B˜%}ÿèiÕm¬rg“;¦‰øOVd6ü âD˜9W«¼ÈÅÄ'M0½BÆŒãâ„»8ëˆ5ãqÉºá7Şü}Í~u·¿0Ûha¬Ùîkéº´ß´LØˆ¸åHW€À&ß­!óR–'-GƒçŠºašNØ,ÇTú* 47wòÜ §ÀôàšM-²hè'ØÈ“·Ú¼9)ï¬ä£@Ü,ÖÈ÷O •8S¶jÄßÔã‰¹Pğå³¨ç¬óÀk†HqKv˜)LQş²óúÏ
+£^:;âd±º®_Á;Aª"g™Uİuì{ö3#S™™ºb5o[+G’ûI#š»ğŞÉ¸~¿E/²•çìIO¿N|˜d¬©$ì"û[”ÃrÜ×ò;;	•Ë x¢Ù16”Ó8/<C&Ñ%O>ƒ|eºÍh:°>!Œó>h$ä¶){®AGÑ¹QóÕ$ˆ_HÓò©¹jÊá?7`æI-²Ò¥/v‰‘)ä±¾ÔHKéÕ2‡,Xuº'¦‚W4aJä¤s×T"èuKš™[œ³ÔÁ7Êc~ÊRuEĞ¤ï“6ªÌd Æ+4aÓ†§´ÀŠ=¿¤üjN/°]Ïğ)ô$'
+òTŠ«Oé‘ÓÈäâV1Èâ2ÉcN;ğ)šçÄÄE,WàW+[ÎÉ
+÷…Óa¾ìŒC>éĞ,r`À·*ŒÜ3éH‡èÃVVà¾3ê¯9'±n+†Oğ¡C;…à\ª2—ÍkÔÖ#8÷â H	5xIíÛ9÷¨ÆÁÿ82{LFÁ0E‚(P|æ«ŠgÁqƒ¡XĞóN6gò[%NèåfÈÀ^¼8`},>a‹o,5pé¯ÄĞdN·øĞÓîœjzt†ÈX´€ã'@1h/+0Š$U—L…»#¼ÆúH?ÍoAX€Es„ı³Éõ3£qá.^\‚Vüx„yM@×S ¢ [ÎÑrK±¹‚.¯37Ï³–/˜ÒÁ_DfWÃ•±üÀcƒp®ÁN6[Pã}±tzËy2ßoIÒsºe<V¼Pg|SdîB‚ÏôÂÙ„.Ë18ã]ÔïÜÊÌT˜cø'³ó›OürU^×ÔÊè×âd5¼E©8†´ŸÜU„Æ+;áÂ5äÀùiÀ·öaÇà· +õ%ñÚf,Ï°$'õPôºzPq
+NZñ;©Ş8P¦H7˜xğâ¥cÍwf¥vÄTlOÁ¾Ê‰‡Ê’>)YÎ*\wéä™Oí«èbæ’`´|©˜â}qfô	cH{4óËkeÉé@ÙÚCT¯#¿`¤×èÈñÒÑœsC·ÌVR„D=­Hkƒ‹şÎ>yáÊ¨Îp[šøˆ7¬Ô—äˆ­"î`vÎ{…¯Í+àş‘HDx—zâ‘'fğ¦J¹!	y‚‹¥×—}O¢¡Œ‰ìq½àéœB3Ó¸4ª”ßäB‘É<¯À™àğCÄ¬öD’5nAÊ3`ÂÆ[ÁŞ)7çp3[ŞJ\ G¬˜‹ÄğFâÎ8£¼¼JÚJ«:àšL<³Ô*Ş,Ã´c‚À`
+[½R¦¤¿Àˆ‡k³œñİùû…£9\e™ï™Š{RAƒcå8ãÎÌmx&˜Zìd‚¸?Yº?ÖÊÁi$™|ÙN<3Í!ŞÀŠêjŠBñŒfFxA‰/ –ÙC¢v[—ï‡^{£ÛöQáË´óÂ9O¼e(ù~iİ}“ÕÌ‡¶"½hxrnù‰z
+U¦Ş¼µ·ô{’EÅºæK¦nÀ»lX-äÈàjp`Y>%ß2Ca¹€&İl:%?ïô ‹x=Òr^ çÍ€[$Õhª¯§D2 SzĞÒqŞÖoŠãMRÚ¥$ğñÅy^hÆ¾X:Ã¼sG­÷ˆÆÊÂvN1¶q¤¥_QhŸHBÑkÙÄHYè;&î¸·X&½5EÃ?mµ¼úÈ’÷åÁ÷G¡"¯p6Oôçì!»Ğ´X’P§}sÇG¾Æš¼úyëKøQÃÆ`Qni'Ï`HµGW¾8¼Sİ`ç?_ô~}ÍÖÌ×Vå7‡\½-©ïû%ñËÑÇÚóoì„·|bz-ÃÇ^#SyÍJ o+“ñ…­JòË-ŒïPâk*„Î-ßœùY¾.0!ğ‘(’d8>ÛÇ-ƒ{š™ÉN¢ºC€=×ô!ÅW&It&¥SÈÔÂ¢™Úqö%ñh¨ölÂâˆ¨`Q*¤Ñd?,‡E­ñ…Ü#¹üZÇW—È«»äÍ!Ô¶K6]ñ1MW¡ëm§¥íXI<íƒpÍÛ¨Ê+mBï›³=%ci¦G÷œmÚ¬ƒÑ3ÜIIœaÂÂ)Eè¸—Ç6ÁèŸCn¶`¶Q˜AñÃ'‘“m¤œ3óbTF›E\æ1ŸåI¡[lYıá-‹-€ëÒ’§ cîv)Hû’´ôµu87
+­iG'ÏxN…Ó×ß¥WÄ2á+â1@‡¡q{Ã/4šH†–õ>ÒJ”Ş JsrÇ	‰Â@‡¹»="_i{V¶ö<YùF×*Ò”tîüN;4şĞJ ]ïØÀª¥ĞĞdôÈ¹z¦cIëº
+¤'b¸ÑQ«ºËW ¬Ğl„È5T­G’ñ'4ÙfÃq
+ggú3Ò^¾dŸ`fæWi({
+à/=áåJßî9ó¬4hû§sºÊ}ª‡RÀä”¨K9­ÊÇ¥¤l€Nlw:ä>IXÿÉÕ &è)6Å{Tij¤>äÄöh7š”êÁõF4@:† “/	Ğ}¦¬fß0;ƒ¹.õ&0¾D¥ù
+0ô	qGª;òN,¡]¤5ïEm(üpA°x¢=²CŞ½=ªèéOPHÿ8åQFZ÷¹pûÇK¢+éˆıQÙ„onĞ=dšKÍ&~qÓ,Û­½~êÛub13ü@¨WJBa!$ğfá0q'=W3ÒóÄ9Ağ¥1g«Œ{ç®$^ûãe£?îøÓæíÀÆõ­)°_Jò}èøÚ$gÒu<–Cú¾ÒÍ·a´~~Œ‹Ñ)›L´=|²ŸG†Úö¨€+KpÊ)šôtÏË°ÚN‰ê×I¾¼İLUìşŒô=®Wã"ç'˜HaĞ·ùãŸ¥¥¼c×#¤v!Ü§ĞóG
+EZˆX“°-½åmÑ‰Ò>ÿU—öÆ=:Ş¤‚Í¹
+Oœ±ÌnÃ”w±&¦?lu¥¤²síÁ{Û½û¤æd\€ÙeÌÕ”ØxVCêá+P2ºU˜ŒŠs·1`¿rÂä‹CĞ¼É[)>x£ÙyØ:×<r"YúkÏ,:İ|şnJ“JÁO*„¾ïŠ€[à5óá{s@ïŒKİİ¸œÚc8íï–#×kÂÏ,³ô¥Móá˜nÜ1Îm÷ğĞu¾75~.÷0).—htÌGš·ÿ‰‰±S«Qxj]ÂV…gÀØÄh¾.îŠš@:‡2\ªqK&CZ´‚€ÊÍ>ÒˆhÇ€sA,8é'¦_š=OÑ/XYÒ(n€^B)Ş½zôŠÁ5Ï6Â~Aª¶aöPïÁ7ô?Í;ĞQøFD¸vñå¸í—‚´i—ÚYìù"„mvátŒ6y‚M!r>&O¡/É˜‰ø]ÖÉÜåÀD¿à©wÉÓ!™ÁQ>"ã“KvÉ“ÇÈx>qtõ¢§Y­‡çÏŞ¾¸Á~UÚpÊ¤Û;Váa¡4¿àFöœGÎ|!dõ8fÜÖa¹¾
+qœÒ°êŒO!¼†^ÿø†å‘€S¯/B{|ÒÉõ´™kpËrM1e¾BhŸnù£ñ„oÚ§këŒX ¿i ¯A¤pOuŞ¸%©7`XòF3İ3fúµ#)ã%ñ€±6FËˆ1ô
+©AÇŒã¢Aä}ş“Ëê¯õ%	¬2úÅ6œjÁê†noH@¯càèz:×Ã°9wxşh—§_Øøû§‰wbíö$[ì5L¡pÅ2Æ>Ñâî†ùwˆ.;®è$ò˜èZD[šOÒf8c\f“ğÁ=ã¯wæPÒ:¢6!O–[V5v® +jõ+[»ú¤W rı¡œ\»pğãŸ{ZÎ©¤Û¦î™fÎ'Ì†=I‡J¶{£t°Ù.ş:d¹šç²ıi	9d:M§bbãm©òƒ£ÇEXpÏFÁ,”û®¯"Ù0G€ìˆäkZ»ïÁZ¾
+Ìü[´LVy˜×°8JÒGš…Ì]b}ï¥‚qÍtf±S^à‰Sa›©¾(¦Öâ›$‰‹,vÆÈÃlµtVˆÅÌV+xª)äÆ@şÂÌ½Öi—¯—¾2ùŠËç³ìd|«4–Èaw¨^¶zäkå	’lfåi1 (P^ËJüšŠş±Ëc^\‹Š/Nyvíf…VßÖİµ¬õÀÇÌ]é¤É2«Sôa­K:É(«BşK÷M£å7¹ n—_yÁê"/vòİà±0üè¨%–™Ç˜_‘ªh«}9ÌäµNa´bkÜv&ğ[œ:¯K]Fë â[C¤t%$“ì&à{4İ]ÙB6 ¸÷+ ¹["M¶²“½–"nX¹JÜ¿^|ø›ÇLà“Ì«äÖàÔ*'p›x^Åš±²‘¡“±Åzw`VÀpè ¯ã YhtÂÉ¬ÀÅ¥¨Ÿˆ ¹š„Ìoí7)3H{Óåw—Œ5 åñ¾eÔ¬d2Šèê’y	N×ÕÈÈ4˜arPåáİFO[M-‚5Øú-E%­j„Baæä(»Î³ì4†ãcg¹ĞÀ²u­ÖÁ·I›ò=mEb®êÚƒs½' FG^Z@ƒA‹q®:¸Ì4š†c³ÙÑèæ("×J“wù¥b¼Û$L4Çrôå0ìzÅÃÀrµ7‹ş¶;/à2“ÁñàTGN[„MÌ@‘×5ó¬á¯gCš“Aà	¨®–årÔ[Ìã®ôay°p"xÃ'€¬ƒ7Ãpasw“`7n¢Á£V¶ü€,XGhãÁBŸFûÃ|¢î#¹ü°‰ÄÒ“éHÍÄÊ¼®»H« !/q€Ã?|1Nà¬
+!Š³èÔ8Õoá‡(o5´…~}AØ$T^‚â×Œ*IW“+`LıÎ˜s‹95¸Šoë'&bâYqØ¾ªdÒxÃ”1>¬J“¯/¼§>)®õ%áKE¯9M#ŠûÖêªym!q®±3]
+dˆÕ²òW-îN†*ê½2GycîNH¦„‡Ìª>õ:×£¼óŠ™í·i}]qËœ—{°K³\KöZí&y*Ššõ›ìp°É«eéä•âƒcí@Â¸^oš s-øò%âj&îÈ€Ï—!ùzáòz… ÄÃ.Q|W4=xıA;û²YÑV¥ëóZ¥åêN‹>˜$ß0 ßBÅñH³Õ/¦8×š‘ßªğ4—ÜÕØ¿»0XûíL…_Ùj¶R‡ÇoÑ7€çš«€Š>Ú"¼YmÓ·P~wë°KˆµÒ~Œ|Kn“‡½%î\VŠ7'Fcí:«ÌYãÂ²è KÒ+ 0äÂx|õ¬éûššl6¥Ù.†zü*ÕE®¢ŠÓ ¶vO`M0ù Ğ‰@²üÌŒfË˜^<2t·J4-µÇ²!qµ9¥=G8§=p@}×
+­€v¨]@2¹½^ûZÑ‘	œÜ bUç(CÔ¡i‚? ‡Ù ÊØzÃŠƒÍ±ÓP Ù4¢ZÓË|¼Å¼]µ#“ŸixÛÕNQ ÁÛ¸Ü~íŠPƒúÀºÖï¿‹-Bò_…™oF_ß*š9•ªŒ¼6e¡i«,¼*/,9€ë#AÎ>†Ÿ°èQ‡éAõMr4!Ÿƒ~…y°¹Ù~\3§cíjüÀƒ)¯za×WŞ¸9U_›·Õ¡6 Hn nEö
+õî-ŸòÁ&›9Ğ½‘÷ë¶4d#`î»FMä qGàFéh•K9j-ÈèıÁ¢<$LéNîşuö K	‚äQ•m¯b5ÄXˆÌ>àó`N˜2D¦ÓF÷[^ZÜIâïŞ@9[6qº_W’p¶Õ>¸S$|¨6ïêìø&ÁÕì8uìüÌëK«ˆ0ãK[º^VaM“¦e½éç¯P¤é(‡¬o2:–
+Ûl(CéT ¨OÛÒ 3&‘9ZÁ¯9a“7Ôø;7Ó#Ën2üLI‰…ÍÁ!ìV¿¶+øJeØB×Êó—É]À*°œ¹jë¯LÁŞ/
+Ÿ²±ø-8pWWÛ­Ìêãòò©%SÕÖˆŸn„3óbyM‹FÚ>+O™àü6º7 „ô[VpšÇ¬Şœ‘úÕ‰Öñu/QÀèÂÖ‚R¼«îöê è%ƒ >v¤È×…šH•0RáWtœ}:@ÌËd‰ÎeY ¿µy÷z<ğ´_İºFÂ¯Ÿ KUSQåñ.Î/W )×JJ³\Lîd†t•«.o«Mú_’vB„ãhP†ED³êqûÚÙíÁH…úMŒ¹ep²Ç?Olè˜ \ÃÛ½sòÎ…cÌpÉ»ƒ+€“Óà\F”3»Yo«`•—</²ñ	úâà3]j¼BĞÓ1‰9ø²Ø|ËÍóõê–ïB	?¶yç;E7èz¾÷Š"¥±”}™Ü…Æ*Œ\Ğói‹qú­Ç9ğğ¬Í–ÈûâHoey×+fˆÁQş×‘%}ìÌ±.O0&K_Â—G€çUWtú	G öª%§'ˆœzÜÕÖ©lKE9äZ7ÏUäu¼3¶¿áİ^ëÑ4Š!z…4‰¿"Q›Ë´˜¸%T×ÍvS³¢œ[æİøX“Œ&{uLÍ±PÃÈeßqöcwğ­1ï¬xµL0‘L‡$“}—=|Ãmê‘¥]N ÍshmzÁÃ#@KÃY¸:şiÕå	p€â¹£ÿ\{òmXßÍ;x¯ `ÄÙBÔ6©—ß'{0İ„Qƒ •ú$†É+èíÅ$ÙWb8ıš‰µ½ÂxM+g¾vÅ×•czéE{³5:…—Ë%}øx—÷C¸ ûË:]óÑ¥m|ı£šÀ³míq÷ÕûÁ¡êõI[Ğ+ bÑ-’oX·äZ—4#rÔ=×ê·AÌbyf¬[Õ­vb.Ñ?³ NÀIsH’vL9¥pÒØ{<óĞÃ©´¶3Ã­ÎV Ø=±œl—f†¹eîÇhµ7ïµxø%BS>`úÏ}fí“CBnåáHÂJ>rE¯!`ÑŸF8™µ{5?M)ç“š°/£ƒk[n¹˜ç
+ê6"V÷TÑzµ¸«nB¢Ä5YœL/FKñğJÌÜOEñk#}±ß|#ç_„ôNÑwfå~j–Gé¢kÚŞËÌRéòÏ½ßBĞEæ ¿¹•ã]b<{ç‡GnÙq-3ú,ÉÄ{/Y¼Vı¾ˆî[Iî´Iç$ {ª=UZÈ§Ğ!Œø˜¡şùROË±æ´hÙÎ¾'r¨z›	Ó.’Eö˜«î«#²á‘/·Py]hÎ„ö–`åM85r†Hßp"7ÂX‘59°‚œ²Üx$ş°|öÊnUÔò©6Ç[JÊp.Dsçˆ)—cšç¤È˜…”ŸC¬‘”ˆÍnpW')']à‘3ıî}3‚Á˜.óg	¨Ãİèò&9ËÊ‹dßç¦Õ†Aå–%M+Ï Doøà˜7ãÚÎ 
+d¿,9gxxêPg’+£şîe¤jJòfÚƒßÊö$(¹²®ïo­Tú2Ò''âŠùİ4½ø—"kP°àsN<;Ñm>\«sÂoÓÈ—§büï‹c¨Ë@ÙîıÂ _ åÏøŞ¿ídKJ®•}P cÛÌfK¼#Ïh*zu’NæT-òw~ÚÍËÌ¸¡Á÷ b/´d"cªñ{ƒ–Ÿz‚›1Àø 0†)Şò}ê–Ì÷¤C–`ëêÄÉŞÏ€¶ü.-V|U‘ïÔ|İÏÍ¯Š¯ÎÁ¯Êãfç`(!cYOò…kD¼P66ó.._°$£Û2Gd>H.h¤CÀÚÈ„u«·cRØ‘Zdd¼½·Çmè»‘½kŠ<Ğ²Q¯èe8#Ş Á:Gä=-N(ãÍ¥¢´fO®N·'ù#2Y²^2°©”İ,±äfKgÌÉl?eòÚ“Êã]iÛ°ÉUƒ[ïÃÌG@tä[=^‡å‹ef& ½=„Ó‘Fn ä|j‹ŞK06òVİÚ*y‹àÍd´#>g…ò»gU sQ’0‚«U„Ü¦$Èõ„ùÎò"“n]/Ã‘¯ È|VØ¬-m m”òWTÓåN¤ùRyS•ÇøÖ.aïHrå«7PşfXÕ¼²Ù`¿pINgÖÉT=\ßÀÛÙšIrV¦Ë5ĞëQ²V„4{ëWÜ$_í¶øÛ2‚*Ø wn‘‡Z}ÌXUÌ=»ÙVkÎ’âz…“å±òáá>¼f"²¬Ä5ö·²ø¶hNşATñ7Ò#Rlg“òu&_{D:ÉPHd|0LÈW°ìC%Ìùv´ù©D‘—
+Ä8K¾PÜ
+`=NobvŒãüù8œ›ÍID™‹F]\ĞÓ©1Çr‘—ö„{¸ZSÈ<à’ßæ®2š—‘ŞÀS÷„¬²­•ÓÁş†‘²‡ºÀƒgs´À©‡i,b‡¡šÔàU¯”Û¡b°;ğ“$Ù¶†}Á–$Á^†ÿÀlõûcW	&rìxiô‘7<epÏëVo|[¿¸³ Şî‡M+íÀehõÜL[·âİâÚÙ0›ê×["XÊ á˜~Š\&Î#ôÕÁ{Ä>`B¬ÌFå©]8†™÷ƒ0•‹ßğ!–¾ÿ™á»`ØeÃÉ1CÙ¨â·eî5ÍÅ3HPá	—{×‹!Š90Â$ğL9İƒ)ß·xxÅ×²
+}_ø=Á4öp=ÏÇ/
+°8RÃOöıZøO€©~Ï€¯ª›Öa Íõ¢Z4¥‘˜Æ¦Î—0wñÁ»ç%mr6¼qÒäünÎ¼€¬·…Ğ;0Â‰åYy©`İ]PÔCnšâò±ò~îïŠ)a+Koğ5—( €áÂˆy'«7ôÅü¢ö}M*xÃÊ\xC-Ÿá‚PÜ`Qlë}„'¹ß4½»[^ÿAÊ7ˆ’¡—…œ#óZå5óôày‰Y‚D‘×FšÄCÈíü•¬WËáeı¯Bo.“*‡°VçuÂ`!ØØCb$ç)^ÿä—Ç¼´ğşu†¹7ï6`±å4Ò{!ë ¶2AÍ«…`êyÆ°¯w1ƒ™ãBØ
+Ìb´¼3X#ÁËWæuô–À#XöwÏ†wò	ÊÌyø*.z…¸`ïÖÄ­/ â
+LÃ|íôiâL‰Ô—ft5t¼ÚÌ¾/‹öVŒTâQ8 ¹Æœo­ÛîßrŸµjÃÚ;§{:½®œ$z¥ë,ÀïM^º¤ëº'SÇ32–…|g,İ‹£Î³b·•â¬pŒlÔf£Ø||¯È’+œKÂ3àyº¹(ß\æÅwIÒÿ¥ ÓBŒXß/¦l^XÅ÷İõ:l$:Y'ìò»Ñ±¯i·+ùŸÎÙ†«:{İ	º“}Ym*Å×¿e9P¶®¢`õ¸_Ğ#F!iİ[…Ç-lúuáˆníÉi6ÊZ„à	Õhá8PûB‚Fıa'kæÚ$„ÎpÂ±$´4L€éò¢:†	ÏËKxlh©_¨ù ”&nšû¶aPîÿÂ6`-Õ‚söpM{,Š^Æô„g^:mÎCO:Öy_-hšˆÓ-
+„8à©úA®”&5“x/ Û/^ØÒèÔ8/KdQ	ªÚÍŒ+Í¥É‚¬ÊÁ¼o:@¶pFÃ8(õ—I‰<yôãDh´+Òiãñ@Ê´Ê¥Ü9cÉ£ÀŠ´©‡#9“Šé •4m“­	åî>]=õû—‡ y”!k§~@;‰ô8Ô`gÇŞ0ÌŒzÎÍÆ‚WfôÀö§Å`Ù™1tò"3¶×-àÌ”ºzÒ’‡]ÉÿF8ø¬"~ÚÂ– 5Ş‡Hë7Ãë_† Úu¦v^ ºª—fÅfÌ‰Û“c5Ó]•9Ğ¸UÌ%ö9¸Ó	&efMfâòK(4›ÁhƒÌt¥ÃÙ^ ê"c^” A‘Tó^¶» Û-ÂÌf|èõ²eÀBÈy:‚tÍá+¿™ñ;Ó$S'éËêÄ¹QŒ¹&íTÍlÍ*wO_ØuÍÊÜİ©n³7°à’ÿäP9S²b‹s_0—²$ı«LHåMÓ¹RãpOîr¡†ÖózûGD™/íó 3³n†l%ÔWêèEb4š¯Vøİ‡L..`E—ÃÌn4œ®Ş^ä4Ã²~3š÷­°EDæê!ø©‹_1©™óÎ‘B<h© ¦™ŒƒGa¹.óa#wåÀğ§¶ Õä-$"®Dw¤›¤¢²×GjÓE"Š²X¢—Ø‹í ÕÕL–{õ¢!_}t–İ ˆ9”×¶º!”¹<Ôø‘˜¯®®\UåÎâ@éPŒä.²:¥ë©É.™ËÍ7‘ˆı¾áZ‘³fO¼©‚6˜±X]*3G+(Q%ƒÑr¾Éé³Ø0Ìb/D_$–àË…n6g9™xÙ&à¤1Ÿ	6^)«­£jÉYó$|—	™·´xRŸ`o¢Y‘Ã´l¸Ÿ––B†(O}Á\@„»C"kı q%cº	¥ä*šG
+£H‘»¢]@+jG9€•Á’Ü8Q„¾Â„)oíMé<™ò“{Ød7%ÆûLÙËKq¶ä#$ƒŠuÍ>Àòˆ$’­àe!¤Çá¤l7TLX)AŠ<àğF¤¯¸€.xO	GJ¥×‚,H¨IÓQTƒ….Ír€4¡v³·È%Ç‘“×r¦|Õ®ÜÉ>Jl7ÔtCãG.
+aæC8‡	Î$£éw!'+ß/åuÉqŠëšSÒ¼£È‚:¼ÊÈ¢“ƒÀ8¶œL¯Kt2RP—ÅÅ	€@ˆï¤ÂıÎe\ÎÙ§Ì¨ÙÄBøjÑ0³	vŸÊÈ/´Ïì³¡ï>1ŠôT_§ë‡4~Y¸Få%¡±pôU²‡!1ây*}¨hÌFB$‰ÛH_ñî+JS¤…2£`=€ ÄùıÒ:ºf#¯ÄK}‰œeüF›]:ùîYc–v5/€·ÿ¡2Ğmaç±ƒ »q’‹X…Âşò@2±ºh=.({J‘l4äî›H ©ÌdæêGUkİehâZqŸ%Em¥…Z^jbú ((¾çC—Ä¹l=?¶'4ã—Ÿ²¿DÂA¦`[©ââ>–d#ªà*p{_òÑ˜ó€Áfflù$<GML¦SêQc[0Hx
+
+í¦Ìó¥É½zPš0,9§ïÀa[Â=ÌšGòMyq0®òíJ®a¸ô¾í°±¹òíà@	ÏŞxı ‰¸Ô¾B¼† \ÛùÒˆ3AzËFè:qrß§ÄåPÏ\È}¡ÀZ/@	\Ã+øˆ:='s.‰h3 íCBE¾`Pa"¥–Úµü¶ğÂJ¼¾~DÙ¥£\É0n`ö©+S)ñšH GZãÔ.Ò¨âÎª<è–^Ã9‹Ÿğµ8 ·³>28“™½s%ÓÜ&c†/©Qu gŠeİò]#™x‰ÃìI}ÓJæü™EéSf€xÈ£"îÓÊ¼Ô,8a"ödCæENö0¡8Ç]ÒƒV4Náå‡IM¯úMåµ—Â¹®çwÏ4Ó`ğ!‚¼&¨òbIŒ:2_%ip`O±GÚ’–iÃ
+U{[‹üõ«í‰ü¦<åA‰7´Ê¡W|cåˆğŞ9äN©=dËûÅóS–™}†ìCjæ@iM­úåˆãr(¡/­åĞ÷É'Gê=V™lçâÃ¡àN€C¹5¾‚Ó.“Mq·®?Ló„“Êœ>•v{Ê"°˜H@†v“¡×1 è-l#àRX´¾ì¼¢ıÇŠ×w“	ïOZÔ§
+|k@}Ÿ½hÊ›ÖÍª_§0¯CIÙë/&x;0‰øWÚÂø
+rv)<N ,ÎK)½Çu›Aâæ›FáI>C¾©¥ˆ_)Qz\É‡ÄU‚ÚWº'á‰úáBö¥½`àDz |‰öÎ×Eˆÿ±2¢Ùœ¨ó]BÅìDy—ıfDS²{&±ÑËávi´0òfÁÒ÷Ë˜gr2ã1¤BgFÙ½’åwÅÂÖ³²í:vˆ|Ãamƒ†_/D”}èXô c¾b¬{²‰ìE¬§_=rš„åÒ}´*´S$}&ú'¦·CÁúhN[•«áh ŒWŠ£;&CšFˆf“AN““êØ)>Ô©”×|l–†œGe®Én’ºVKYë)qïiä”İåê9>˜Ì4²_s´#eA¶ŞòXâ:,é¨VÍ$ïPŸ}_;L°ÚÌ$_òò×C{©*ôåDµmšG¤bƒI!å?¡3:„%­«—÷¨Ñ%JáLëúpm6h`L[›Î"—àBfh{ÌŸîÒ”ö q{Jè×j\›>´Çµu3{J³®Ë¢¡Àİµ-'‚dúaf‹ÂáP`…µÛZ´ÀhKé1‡–r_º"}“™>MqŸA,ÌrÚ¬O–şD@7Û¥ı=
+•öB^­­–¬ï ğcz¹êCVÏyaãé”»İ´G®y“p¡yÒ«5ƒ¹ìZxÓ›´CÍiÂµKy¥•xiv0­¢’pÓw%/pŸŠ¯ÿ¨ğ!
+p\Ü¥¶P<Š‰OXeü‘”İ QŠ}²Èé<´šMèÕw„¸–“‚Î´>6×œ¬~ƒkù(¥ı!Î¬ßèar&qz…bÔ\Ç\€ˆŸöÂÄòN`näCØ®¡‰-§lğ .3Û	ÔæŸÌNÛ•}1ÎKå  k)eÏ„$Ã‘gò
+ùÔ•f#	ÅıÔÜ†v£FïJwÄ4œ®ı†Oòdkp<èƒá}ŠÌr×º+À¼û‹'ìêà_|?GòcƒiòŠTWÒœƒD ñ¬²ÉGq©mü¶!-ñ&I½ğ¬><—¢³êEÂ$çXœ'>ÕXäE˜ç`t˜wBì‚T1ãd…AòŠ6i›O“ñ½“bSÛxds4ÑÙ;íéW'¸¿2•ÒsŒ4é(U0~–zåOˆ:ö†á»JL9Ò ½$‹sñi9QéŒ^İğ­h‚1ÖªxœL0Âì8è!F·åFdfô”*A¿š¢q Ğ¼şJıüŠîÛs~\¿VšâTeºj£'cnò@î4K.L¥|ƒG*€EI\NìS‰-0ge‡cMí&É$$r	U”ZN/8+ÇÚ	ÙèöœG0Vj‘3hÒv©#.¾gD9ƒW3*QØv&/ç©ú¸¥/6egğÈ…"äè¦Ö´ïµh8Vp|÷” q8=kÛv§Cş†fìO\²ºpkÏˆYu¸½Ş1cÃ	Û <(“K¿ØÚ½Ş“¯¦ÓF·wÊ¹·iÌ‰ğ‚t„ÛŸ7À‘ô¤,úŸ¿s¡/4£Tóù¨ìGd}½Â,é€œvWÂBÑ4VØ¾í‹*péKR|A';™Òi+pWw#0,úÅ„ú9œ3ıCŠÔùÔ¨èi±‰tˆóÂø’h†Şrº{8Y°hLÒ\òœğHî6X4¬àÒíp-_ÔA·›ø¤ù›ÑĞn¥ŸÉ½ —öLGz/Ê âzà¹’ŒÚUr½:NbƒPâqAD öú2Hp¢ñMEQ^7ö@	q½ëtû«8,ÿ££ïì…x*ÇŒ{€ĞÄWÈSøÂ;*²šñIÁ/es'C¯¼Ãu	ğ—J¡é}óB…½‹—%¥t¾I¨İ˜“7·8üP³¤âGé/m¤iNiÎê¤¼ ŞKÑŞ‰cuÌrGX/²Q÷¥ó%Ä?9È^À]Ú×GœÜo=)Vó+£1“‰Ï•bP¶
++v7TĞx h¶0L¿ÓåEf«CHÃ';Ø•á¶ûK+z?¢mnœÎÉAÎÂäúƒ‡s
+á~À6=ÚVôÉ¨Gr‘ÙªŒÖ™ Ğ5‡OG$ õ¦E]£@ì§t|€“¶.Aá’b:üIEnwĞübª3©ÁÒ3HP=³Ëæ¡ôîyeÉ¡ò€õ=i^ÉäìS}qzGZİØ>é	€îÑµæ›YR Î–.ÁèxÈ(­ŸB4jb8NYxØzpXéŞ¾˜ŠãF§´]ºä™~`N„ù¢Y1G\“‚Ü£–$é×_ß´<û‘RŸ²®Ş3DŞ™:èv‘.vn¹CËƒÏ´i’'º)»QSZ1ä”fvÏ„¦¢[÷”¼3”Ä¥>äuÇÏä´ºÓ%a	ğõNÀ*ZBÕz×~!ÅÀq@»Ác>h:o+î™5õHÜÚz6ãòX˜œy§öZf›yLÇk>ÌJs>i¼LÈdGVşÅ‡è¥}ã%7~¸Y €çrcÏz¬âM2”‘%um·Mã¨¢'{öP<U3bk†Ô‚àS¦Z.œiDôd~gMc‚Œ‰ÄîÄ$iÎ2tÙB»+mÉ&òçÎ‡Q½Qp©‘)ÒİML©3wudIT÷Z3Ú&°]Vl³p3f]	GÆ”€{³;jš‚Ù’ÌyUåZµmºÃ,™œôSÍëK+¦ÜY{Uo[š26œKµë¼äDSÏgQí]DäEÈ!oãàÕ¡:äK ÜŸ½ñĞ¡1ŞdIZ»·•95X&y3hêh–q‚ªL>Ì%ıƒBô4O>şYdœô%Ù<)†ôfq{­aCÎ™ “'3‚ìC-2%.ŞÅäLèÌ1İÌéyâZŞ½VAe4?N¸p4,@ÙÃB†,CıÖ¢‰öğd˜!Xık7µw\.åJQµ{‘ Ñ.@³2+J?+Åj]r"X†‹€Ó¼:s"¢}Ğ¡æHHÉg=Vi€>¹±kÅÑÔö	°¹Ìgá©hgŒäÃ6}_cÕ}Je9ƒkSåvé•¾ihw4.l­97 {Òù|âm“"èóJÿ…GIsN˜“5ğø¹—™Xƒ®YæÌVN A™6¥q%#2=—Zk&7z¼Ê3´­”É?^•À³Q©,åÌ»Í“‘±5—QyòQÌË†æút‹•¼ÙJî„¢‹|‰‘/|ë…®¨™=é ou§M9ğ$C&²=…[«‚“ÇœN`Ä_Y¤‘9µ¦Àµ‘håÈ¶hÇJ³×V¨eNQ¯ÒãÖAÄNdN13Şõ¤²«T1;ï¨¼êIMÓbÒÉŸìÜêA’b…5oÊ™ü˜ÚNE{Ë›90üHñAy‹9“Âˆ»©)9~BË‰v.¶«)mÉkÏRQÀ;ãğ6÷ÑÉ»•nè—Á™¸üV„ãj¢½Ú,³ƒ·±g¥™é7ÒÉl—÷Z2ÂtæÁ"óu`<V'õ
+4\rŞ¤_Í]éwQ™®±ö_VX{3KV.d½=X-Â
+c.Í:Ú¶D‘çf‹<ëDdÙ¢la¶IñÊBfù‚èhséá™Ó–ÄÉŸ·ZÌ%i>Ó¡&_Æ lÛª¢\¥@1w&éi3N*ñœ	A™1·BÛaâØÁÀ|¥¢Ğ9‚GK±²¦ËV³Äv‘Û–ÉÊÚÈ“!·fH¼Å†-ƒÃdšVY2S´ÑÀÅ
+Š É‹£Wú¶Lë·îUEN<Rk*’gß8Cp3çÜ>öíD0ògˆÅvmp¦ûbŒÈJ7:L,^« •‘-á8ô:“ÆÌ(+v€ÒR@é-7¢rã¢`o1ê)iÌò£I‹ùáÚwVäæLt™Uİc"OÙ³@ë†ü‚	j±ˆ„>ceîzm'_@„Òeà˜8¡ÛŠ\i$¨·éÛMÍ™o ;É#â!ïnä	†¬MEkëŠ¡PÙ0BGùdÍ†¤5²ƒÌ¸&âš/Ë|Bc-{(–ãróOMk^ÌB‘pØÒB”³#n’Õòô’LY1•G^ğÖDè$e	{±¹îŠjÁ-“%4!ÌHhöl!—Ü–8&ãYPm*oÈd®¿ÆŒ§ªt—8ŒYo1/XõÒªì2šÙ˜Ì§ÚX¾AòÙÁŸ.‚™˜¼0ÈxJ$VÊn&‚¢!ãe©j$ŒQ¹é”6;@ğF#MÙÍq¢zÊ‚ëæÎÈ„ß¼"éõvT€ØÁ¨¥PfÁP,ä>DÆfå‹óå³Q–õà<öİ¾^#dM~PÚ¥ÉtYì5yE~ÀàGë¶ í,c.r] Â®ÀåS.sÆuíÖ£3²!»åVèÕ>°àq ëaÑM$³ç¸ğËŞJz‰mñV]4­fĞ™ŠåCDûÉÙY‘ùüÄô“@_jq•ÿÁ4-‡@2˜3'…v}ı|Ñ§lŞÓ°Ø«-ö<éMvÀV¥§(ø‰fÜÉoh }=ˆ?"»“ó¢,ûÕ7-áÊì’ú2X4'#Û%ÊiØÄŸ'-Õe¸E0mzzø‡nrœÔb· ;’g”œ¥­›|F¹×£kÆƒ"Ò³­¯·r½Ìw0ö´«³'ÀÕÌoBzL¥c%~æEXÚH6p/¹»uèYb§²!ÇAı4$¸{Ye9-.:µÔÇµxXæ¿³¤ÇéĞäæÀF<-«¦âYñFş#s×KŒ|1“És·)HS}ÒóJÌó¤i!<É›K22Õ];¥	>Ul“µ  h"¨0+³yËK‹nå		òËT&\û
+c.#ú&›­‘µ*	"X…¥‚¼õdª½Œ ó:A““Ó¸DÛË¨n¿àÃÊiVYZ÷Y»À‘”Õ^ø5š…Ñ•œ ·µ°é,”DÙÊ±J‹‘[Ó¶Zä¬6ºğªkClæ+2Cš6µI¯ÑP”µĞàvC­¥ãä4©ØÎEjĞh°|³V-}Ä—vÂzš×Lô˜<Ì9óK§"¹iÚ]Ğ¬6¡;‘]ßn˜ÌW(Ò´l…}»j˜Ïj'ûh*×—ö&«—<| XŸì–¤®@˜q$0>rÛÙ–­c|”ÙEcŸJAÑu‚èrVfb+y§-›9A”.’´áb80d2Z¯F#Æúdä6²ºV’htµ ¤Ùm²Joñİ[ú|@0±ÍTbÉƒz,ä)À©r…˜«±œ=:z<Ùh	Wn2ƒÛ°CÙè‡Mfú@¥g•ô`!s“`w•Î l»Kö™"Ğ°è`G8rÓm[æÅkæ@Nß®™õRëD„N!p¡IéäŸĞ­…­7,ÆÉISxúÊ,#m5G‰l#dw:·LnºÚY<˜è[º+YJ´ŒAj/¤“YhÃm§ÙQØµj³Ğ‚­f„c.DkA[mÛğ›ZClZÙ¡cs¼f¥9F8wÎM£qL’ˆ:1—¸ÕÌbâ&¡SXÊ.R#9-€ù’ñêŠ
+]¦'Ñ&À¯0†Ú
+˜”—µm`#]/ÚÊ |´!ã!˜\ZŠ%¸*r¼àÙ$€æƒïR&ÜJ†NãÎ8##VòæN×ú±èÅ
+pÇí(<4íšØvW£rĞÓµ°x8ˆ¬i×ÂViW9&°–,“İ-rôé‡Kìd4©[
+«ƒìñb&¡t-Ë:Ù¶>w8†æÇ¥ÑÍa(L :ÈÙV²¦	Â¥E¹uı©¼:³ÁÑö›°i!š¶ÕQú©.›8öé¶D&9¤à¦4mU9;îxQ{í1Vd@CLÌAQŸ¹d6:ûÄ&Âxt*!Œ3åûë[/3ÜÂ©	/jIê({½n´À
+í:		Ä¯ãU:F±¥dÚ±’¦áOamŠ(è¸òuB·
+1s•A‰s(®ö–9­7…r¸O’^íêo†xÏNV¢äÀ—K’–1€¯ÇÈ5i"Ú`R^ı$ĞG·Xu_” j#’­æÃæ”ãÑA¶é2ˆ«X“d£6aÒyÀÔğg†ÇşQE´ñø°/İ@ô×€˜3 ƒY, l1KN]'‡$^œ1ÛE’ˆõîÙ-qiÖB_d¯	0µ•¼€Äd
+ìğş³Å( €AÄÑâ šŒÓ$fğdÆ;‡Hî*°	ÒNŠum/g®¼v¾Xq]¤~½g'Æd»4úÔ'E\S:ø-V±pçµqD \„¤Aù0&n4Æ´ÚFÆøxëp+Î.4}qG¼°]‰¢vÅäğj‡—W“Ü.bz‡©e ¾£"ÒOîšàDYpÑ™a³²ayå¾`5/»&ÓbÌ•ƒ18ë©©S½ÄÆ•QCYÓB¾(Äa¦À>2¤útÎî‹¤²§ùĞ,FÔÁ>nPû5Œfë˜¤ÃenGš¶Úk^oq—*ı<´ÿè ƒ¤ªusØp"¢X)DXAŒ9Y/±9ıÚ*›c°~±œR‰»Ãd8Ôy™LLµTH,Ğ¹M×â"_¨§Å°¯…½2P| —ÊŠ M|ñĞÊyíŒ”º}Té¿.A^šv°mE¡Äƒ8ı­¦S‰Ì¼“uzen‚kÃ+ÄCL‡YÒ¦ï<i[52˜Ûh„zÜ'†€/Ğ&dßz>€,˜×A×‡âÈu HÄÑö9¶'3î#gIœ½­êİ½c¬w®NEoÃ¦ñL(â%Ë|ÑY((áwü¦É“ÚAÆàbˆz‰nOÙ³üB‚Øü¦aö,×SC0k¤·=Å5Æ…|àùÂØ]lÚÂ"ïJ@ú…#…§•DÅæ	dnÚÅkU“Ñ¢Íœ¹SBl®Ñâ&‡Zô)@ŸêÁH›ÃÛWËÖ’á&êÑ7ÎhhXTuK[†Ó´ê0h‰m™÷ÙZÚx}ypøÑŒe:5qÇ7H`k“’Ù=DC«àò =Çàö”ØÍEa“’õW7|¨0°¥¨ŒU’Ş#®?hiĞ¹¶ntt¢+xö–´1ßSĞ;¢j[HŒ;9Ã½N…
+ĞªInó¹®B×«„2Z”ÎÖuÂ¤‘„Pƒí¬‰éT¦ıÊ‹íHh×)ıÚ†‡Qt~éØ9-:Íhİ÷ƒkRK±1Øf”d|·<µh+IpMë%é;äÔ¯OóÆôÚÄ;Ú²l©"éQ-›
+Rn3UÈÜ­Gm»I5™!™÷bšĞ³˜/ÚmÌ¹¨¨ö,Õn97¦Ô¬i“=IÀ)¯šHèŒnR'"È=üRº.ã¡+g™Xğ&"-ëg!©è”¨©ÈØ€Û ¦=‰nçúÀÁ*6ÜyÑ Š>Õ‚åNö$1İ^5êûqCæO2ôí§W«‘øù‘ànŸ	Ğ_&‰YMg­·P˜m6ˆ:ú6­l„Şñfû¥5©ØZ¬\ù È½êâC£Q!åSeuM¤‰­‹`xğ £Y}úZ£›`Ñ} ‚2­‘±cÏìù¥†x"]Ø79HkÔ#ŒÍU×©¥ÒªPÎ~¤BÃùñÑMüÜZ7óPŒjºÕhèDq&/¬ÁĞàÑu„Ä]@¡Îeºì7w|“¥.²äôj¤­a»íÊˆCñ•öé`æãxi;\ŒZˆ ÙîFÒÑ‚ h&9
+³Ş–ßÑDÅú‹åÎ3éänt¹[¼0ÈşªIM§"qòF^‰PÛ"qñ:K¹u3šÍ¥.ëÉ¡oa!Ó_2QÄÑµl¯³vöDßjtlÔeıA‹ècY„Ú¶ÈS—Ò9ò6¼´²EØN¢|
+È]¯’İö™îzUT/ñ±m*rdOuJÛ½f¨•d~y–m^ƒ9ÚFØ
+fÅE›
+áv,ĞWÅµ6lÙ’Ör†Ë³
+[—Œm·âø;­¸×Y€@|Ê•^â­YOx Àa×ÒÉ6C7ÿâQ¦l8Ó°o
+~…#©“H6‘T¹g¥Ò^FÄiÕ%('K»6)ĞM~ø<L’NÃ2ĞJª`ş,`·–‚µ)O0WÕCZ_û
+Ñ‹g}ÅuÚ+—Ò<ñ­WÇŞ2Ï¡ÎZÜŠ…“†beÉÇBmßõ!¶½H’>‘0èh ƒİ{qŒâ¹ªhÓ1iò"”óÑ…ö*èc>ÀÕ×›;Ñ©A•Ì³Éû2ôGí`Õ'¶ÃXì‹fì¹dây/¬s5¹`’)Ş—%Cßv
+À^n0¥Ø¬CvŞ/(‚ûõ…h&ƒİJt8 bw²§\©ñ¸Á¶¶â&·)ü¼M:•ò¬?àıı±ÉLèz`\ï«¦…¾i%º¬÷>ÆiÔ5MzÕµê^T =„²GÄú`ß”ö‚íöKÇíâu‘¥ğû¹HÅ>C•¤á€…9œ£b‡a0÷SŠ/<eÒ_n³Ü Ušï¹õèZNÌGØBqo¤måSn˜àêzL—¥Ë,GÖBù&ŒÀÖ‚g%+š¶İˆ>›Á(œ›dwÉºËÆÿ9«e³Z³æäÙ-DéÚ!ÚüX‰ä“²túj¥ùğ€…_CÚ` ¤ğz9d=âA›Ìˆ k´êtXè#”DpnüR¶J«¾Æø>ès<#­
+[ø…€åÒ ´Æ¢N‘–u|¸MÊ48†wÌf=$ÏûE¾[ `¤£ €Ó3ğC­‹d×¬³RW<İëÛÖ×BøæˆÛI»fÂ÷sÍfZ–·OU®¥|©ô©€s²ñj]Û¯lÂpB;L›%Ÿ@dwJ×Õ&Ó)á“uh´¦ÇìqòÇ×ìí1»µùĞ‚jÖ@£¬İ\¹“1¥pŞdâz%±39LCæ<ºĞvÊìfk ù2É·wñ”d „_r%kŞ…C‘—ÚÈfHL§vä0kÊ½i7· ÀYÁŒ9fö"k
+™Ñqxá[ÆdJ7îsZ ³z^ÉZc]Wm`•5œ:i8@ñ	¦Íü©WÚxÚ¤áÄ*VÓ®EãéB‚5)ÈeLÉ!7¢óòªyİ‘!‘>U /Ù“-pı¨Bï'9ÙAÿ âz½ØyÈ•ºwZC#IåKÔ¹Éóª®•fÆ)?rLá-±•Û˜.ÔCñk
+˜%;²¡ğ£?ÄvĞY–YË•äF§8œÍZqŸ“Ğ/ªàäÇt—ÊZêĞÛØ|áãÖ´tC9’‡/å(M2[ búÔ‹^‘ù”pïTwÛ+ÚÈªpj¡IMpåD=¬/1=6)™ÓBß¡øB´¨™©,)ˆû%T4M
+…•7}f¼)Æ\3f1Ì–š\…Ö, ™òáÙß‘œ0i{µÙpLã§0WôŒ5pÙÎ˜i­èR¾2… =tE×%òLdQ¯_ê:ìX¶dM.uW"j¬byB
+gRıö	R+Y²ôìr÷šEÒ†<âQ¢Í#†œøäêRA Z—³HNÌªl6¢vıêb7[ ÓBLK 0    blsc      ))      ))      M(=gÌ0KÃhI@½ãÂ)q  )%‘(M  (M  %)     )  (µ/ı`(LH*^gb`PYQ:a¥eídıh!­(VñanKU™ö@Érr¯Ï“…èRafgHK³¢ƒıp¥+u÷eç¹qù@@nê€˜,¿ åGä(qÙPÍáBuŒê…‘úd©+Rîj5¹½É½q ØhyË¤<tx£ äMä#E…œ÷ŠkŠ‰omRWe˜°I=Ï ù¨qãóì6Æ{_•½Ş¤ôÊAÜ¨’İê˜9fPì¯)bí™”Î ={âÛå¦BÎ­Lú®ÅÚ›‡·®™“ã šo#¢7ï&'İâĞn}Tï ƒ¶Uö:x^rLaŞºfo¯çR»Üd/ÖŠ¶XNŞ`E»½Íb¼¤[O´I]E[¬õêìöª·¬õÖ¶Ş–Ê7Øº=ïÑ“£ñºm–“«o”ŠöNaµ­·ßı1=£äÌµŞf·fgOİ­m=zŞ ÚÁóÚ¤şÿÔ5»"ïÿqPíöªyÚz¾+~·„ÉUÎkDt•ïÕš]	™ô%÷öÄg’œcÖj[cåyÚVl“:öÄÛ•Šo³£fw›‘ãšRäÁWªc™ôšİmvãÕÎkc¼£¶õ¸T¢hGK*ß5":^©H¤~·È;vÍŞƒqìyK¥ìuêX«j¥2»Û&+n|“ä}÷Xöc%Šv”OİíUQ´[Ü+ÍE;vÍÌî8Æ3;ÖŠ=ñh¬<¶­(ÚsÉÊwƒj!f}TG¿+{áÓqQLê‚‡ö,ÃÄ-9_}f99uÏ,xşMyÏgv¬õ¸F<6;”ÜqŒ§cºg0ÏW–Êã"ï'£hGÏ{+Q´ã ÚwŸ¯–ÊóŞ®)>ª÷ÉÚ*ar=ñØYN~÷Ö¶>«dÇ+Õû»Ï§î*ç[¸ñXÇ<FÑşÿ(F[G¿{ì‰®Y©¼]©HrnWª£fgKeø;f­3H%LQ´[™”ŸE¼nkÄg©g;o)Ï+99z>9zñzÛÖc›Ôóò=tlvÇEŞmvl[ß'„’#‰Ôñš²‘ƒ±òùäèã¡­gRz°T^õ8Æ{Ï‡¯zìšßäc¼cÙëøÇôŒ¢ù¨|TÏ6Z[LÏ!Ë19>‹µç«ol8¾ÉİäQ´cr1slDôfÁó<t,{½]nÇ8´cÖú¶ÑrìšÁH9Ú)Ìc™ôöê­kvÔìpãÑïızÎ{rdvÏ8PóOİï™Dêm½sÌ_õÙÍ»ĞÑ3_=öQ£ç}ñà¶_Ä8ş1½C–g–“ã5åıçf£ äøªGqã[…œc×ìÖ¶¾Wªï4»÷œ9ÄÌÑRyÔ¶>—09Z*o¯>“äÅQ³;úİg;Ç§î Ù=³à9FÑŞóİç@GÍîàwoq£õÄ«|×ŞäYëÁRyk[ÆÊƒ±ò¶F<>u>ªç’•ã"Èã«ç=¾zì‰o¡>j[ß!fŞ>Ln¯*ÖH¤VªãS÷îÁåèysvÚÖ+·kÊ­'â@9.•më[…œƒgç˜9zŞ[›Ôû»±ò»WÏ{ì‰Ï#@ïùîÁï>{âU¾»âÃAÜx7>‡,Gq£GmëmŒ÷,{—Ê[r¼ÊwŸ]³·'¾{¬_Õåö¾zu¥z{â­'¾eÒc´uã½UÀ=o çï»fïS÷n1—Ê÷	DïŠ¸ğã}U´u°T5»÷ï¶È{ÏyLÏ#Èw™·šg’œ÷ÉÑ{GÇAµ·êXÇ<¾ÍŞ$RïD¸µIİÖˆÉñö»cåñÕ[™ô n<•·²×­'Çx·+Õm©|>u·fw+{=»ÜnkÄ·Jö\#¾ç¼;È3Ï3H·±òö6{Î1sğ»ï gl8+ß%+Ï8´«œ÷}Bè¹ÇÊU¾{ûczv¹é˜ïˆ¼Kå†nÑÖûEŒwšg”ÜQr|“ã±êöÇôÆ½½ê›µ¾o³·kv|Õ·Ù½u€ğÄ÷Œ·:æûÏW½]SŞ;ÈwÉÊA³{ó<³à9zŞw	"¼G€Ş.hŞ5y oÍîİIr–Ê·Ù=¿ˆqKï„mëÑRù¦AöŒyx.•o•ì}Õ÷wß9fCÌÜ¢hoÕ§ï¢ä–JåÑó:O,•*`Şó­T9…ùüÛó¾Sğá™µü.kÅòœa¤È¤·Ù<ò	¡ç+Ï3n‹¼ó’Òg Ş(h‚<û¨Şfw’m=ÁÉ;d9Z*w˜ñL"u{›™¬Õ5»ñÅA‰Ô1k5»ã1!ÛúÜ[L¶õY¬àÈGe£åÍC‡·lx¿Àc¥¢	²âÃ³ivGÏ‹¶PÜ(“^=–½¬kö[:¦'ßäTÀË¤-¦›FÉ™İñì=ãÁsÎÎ±Mªràƒ›Y°á­BÎCTéö‹·±ò¡ˆ×ñ©{h ÛÍ6Z®ò]”Ü­kvËZo³§bíùHÈÈÛ5å!0pmñz¾É½]øñğƒ7§,Ï4œ$¼Q´‡%+/0¼xzêJåQr„AŒ¹V&mÏW}ÚÁ÷Œå‚£±²då¡H¸õQ=Ó¹½ú@÷ÿÓ†¼k ]õá J¸E{×Pä(9>ò\‚Q&pû»·äøğö\$Çs©|XÂäª–g™ôy‡o8àØ&uÌsø,ƒŞ¶õ=ƒôœ²„ ÁÅAµg³‹õwŸQrÏ+Õ{Åócæm=í èâ«ŞyçE[6©·L*“>«€¹=ïiÑIÎ­m%G×ìª·6©ã«Õ~L9fce¬tA#ÃïO :f­¯¾}TÏ%L6À£ho"&vPtû$¡~‡
+@ÀmrÒhëİƒË3!o—[X‚mRï„Ş;Ì¸ı1£­‡ áawÛ+>¼qhàÁl½]à€‡°]ë£zã€¾}To’¡¾½êÛåvêŞ%+7¹÷Õƒç­mR5€ng<¸µ­;È[Z8‚|fÁó»ædÈ33\³ß‹ïB(•#HÚĞÑ›ÜQÛºRİÊ^Ï3„pË7ÀÜ®)=VnkÄÛ!Ø³#Üş˜rvHrU²ä³kÆZŸYğ¼a¤¨d'„Ş§Ä§nÆƒ7‰Ôw]³w
+óıİ79– ‚m…‘T;Jï9ïò¨Ù]ÕˆÈˆ¨N¡ho–“çˆğéÍZKVĞJîÖGã½E¼F€TÀ¼Ié{yµÈÃmëJuĞ¶ºf%Lm+jM!‘Š•Gqã{è²¨€±FD$R·®ÙÁXY²r;³­·EŠöŒ¢a³d%‡,(Úmö"Ç!n<¾ÉY;±òh¬$Ñó–ÊãñíšeR+K˜àFODÉı˜ÆJ’óÖ¼úú¿Rü.9Õ1ŸIrn}TGK¥•IL·ç]ñá=çUscå±ÅûÔäˆCÃ7¹÷”Ê÷œ¸T>Ÿrˆ™’Lz´TÚ¤ÆğšB"…—”^å»#@§îxöï¾GÇAµØwWªRIJÁó7¨ÆZŸKVĞÖs +[Lfçšy±ò*Ú2»cÛºR:±v|ê¿û{=·˜~w–JODÑ¯zq‘w»¦ˆµ[ÖzKäˆ‚O|†‘rœe˜8F[4AÍÌC‡ã1dyöÄ[mi¥zfÁs0VÚ¤On¿k£E†]³Xy^<»õÄBmëÕXù<ÄZ¿ûİƒç=92;Özkv8´w©ì&oÎÁóÎL8–IyèpŒC»Êwe¯c™´†"Ç7¹7IM÷¬Tâ€º[Ús‹éM£Å[Ì³'ºfÏ®ÙíìêmXä±à9X²r»RÁ–J™´Èûÿ[Ù‹µ>£äjdÒÛ•êyÅ‡g/ûc2"º5»çBÇ?¦"F‹[×!·+ÕE;Z
+S˜Ï%LŞ'„. ×^=&Ç‡x|“»½Íº˜Üü"ÆóM.D™ÀÍ"^ïñ!ˆ–[ó9gç¡pómv0V>YÀı;{¸€\\#Á~÷ m}VóÔÁÅß}
+ Ü6":úİÛï><Aâ‚¥²Hãï>óĞá!ˆeÒ‡ y¯ $up-Šö!„7ŠçZx•hë9dyØAÑ°›G€†`ÇEm}öÄç„Ş>L’cñ:F[ïÓU¾[ä=òüİ·	JŞ®Ùy}T·®Ù3I6<«ƒ¶BÌ˜İ%wÑ[¬à(V¾KğÁŠoRx½u€¸½É©d3”INk
+ÛŠÆCr•ó5IÎ±'Ş^EKåšrŞ1YëªÅÚ­I¢_Ä¸5"*aò1CW×Z*¯rªœ—n‡`0RŞó¸1…‰Cûîé*ßEÑn¯zğ»èyÁÖÁó¢Ø¹Šm]©®âĞYğ\%µJ¬d9Á¡ãÆ÷|·È»Êy]Ğ¯T·Ù±M
+%G?&)ŠI¤HéUÎ[*Émİz"INÈÚÖñê±kv+cå©C±sêlR'„Èñ6»ıîJÅZ3ËÉAÛzüİóÚ"ï(n¬]øqTÓBö2»5åEcÁsü]Od­±³à¹ªÙyâÑóŞÚ¤ˆm+ËÉñlÅ‡ck­ˆTÀ¸f¥rèù	ï3W9¯MŠ‡äÖ5KYb¼gÌÃ
+nÏ+>ÜÕtÌƒäø†!…›ÜMîÖìJ%‰ÔÑï‚­ïâÆ•êèw]nW=¯ËíùäèªÏ'„j(ò<3áùª“c#¢÷‹Ï&(yÏw–ÊçSB%LŞ>LSğáØ5Ã¡•oàx•*ä<ã€¾ç»;Ì`Á†cÙkÈ5;å%ÆsAsì‰¶õø¼3„ğü"FÑherz–½nrÏ;Èç1æS§Ä³)Ë1Ú2äö“½ƒj2èá¹ĞòÅÎ3IÎïÖˆèmv1ŞÛˆèyéV&õa¢æÙ…Ç¬õ¡ @p19Ÿºc´õ”Õ®ú|Õ3Ï3„ĞƒËq1zOÓ ‡ã«<$ïéŠ”Ê7”£¶õ»>fW#–Ê Ú±'ŞfGÉ±È»Ê‰ƒj?˜Õ¯T'89–½rháøª,xd¯‡ğà˜Ÿ,à6Š|ğÅÎñmöl[ß$9#Hà¤'„Ş<tx&ò‘<û1=×Ÿª”·shá™‡äÈ·Ï'½{¬¼[ ÂÁó>üîÃ”ï‚ß½ıABÈ²‘äÛìŞ2)n|‹µãşnÎÎm&bây"·AµÛ•ê¸T>L@.^©h´xîÁåY†‰w•«ºğã™$çiˆ™£fw$¤<@	=ï‡öºÉİäbB¢ÍL(òdÒ÷ĞCPàZó™Ù-íó‚4œƒf÷Ö¢È{ Ü&Çgr|*‡`Ï'8yÇ 4Äèy"<»ğãl=!„«œ÷™µ^=6»÷Õÿ¿ª#¬àö‚¼À å)8¸™F‹7x& 7¯Tmë‡vêŞE^ø¡Å³ƒw:0ƒô>r|Ş§#ÈÛX‰o&ÎûfÏU¾û„æ‡V#>ñz{âS„p»„ÉíJõ ¸ n|®ôücºÕ16À7ã@y¯àöA>§0ÆÊ‡'G*`Hé³Ñ{†W òğC—ÛÃ‘ÜL’s¼¦¼w˜¶=1…YC‘g™ôéznÏÂsŒÇZ…úi t\[*>`üîqŒ÷ìrKaºÜB 7Ó {FÉ=d  n‹µœ<= ˆãñ¹då9ey×ˆ79/óÙ…Ï.hnYk-<<uWùîÃ [I'ÇÊ3WE¼Ê-k™@’óŒC»-òh8¨Î1ó"†köDË©{zõdÈQÛT›ñàdjvEr¼aHáÙìŞ0¤pBèMÃ9öÄ·ì%Ã„ìåšÅÊ šÙÅxï¤“7)¥á°œ¨sô¼Ï*ä´˜\Ğ¼Qâ‰hëö»'G±’µŞøPì°V#¢&Ï=VV|8>ïÛFËQÛÚc¥Qr&(¹mğ›İ›”^õù¼o-ïfÈ"ÃÄm‘²½šor·Ww%+3Ho01ŠöA ]n'G²×»d…åÅ)ıîU—µ–ÊÛç‰¸ñ`©¤Ñâ=ç[··¸ñ-âu«c²à)òjÄƒ±ò¨ÙáÆ¤Ù o‹¼cÜx´T²à‘½®‚fwÛsŞ÷ fwêJ¥
+9Çäè‰6©RÉrr|êŞ(v:V~×¯ÅhKå»GÉQå»WIéQ×ìh¬Œ•f¢ßÅ84”MêÇXsH&Õ1E¼J˜ÕbåÁï^å»Ç7¹ï¢hÇWc¼ƒ¸ñ»C°ƒfw[#>Ÿºÿ/•®™ùFÑPÜè£Â¡‘ c¥
+˜Xy|Şï(n¼ÊyÿßöœwMÁFDGÏ{Ğ]Ğ\%G<ï9¯	#å¼C°5%Æ{VÉŒˆo|c%æáÖ&u“ÖGuuLpV*×”ƒŠÛ«Gm>ªƒç•½\3RzĞ¶×ˆè63A‰–ã½u€¸uÍJFÊû'Ç5âòx¥Š•Gq=Vn¿+ÖŞs^-ÇW-A„[×ŒµÚV´uÔìŞs^OİÕSW²ò±òèyqãmf[Ÿe˜À¡İ:/&P´‡$jp›ß*™¶õÙ…/bÈ^¸1V¾YNŞ@†<‹5"&ÆÊwxô˜“£1@³k1½Y°Á‡ÉÛ&…ÍîàĞMn¥"Ç 4ï’„\õ»Ç¸ñaX\´TÒ ;zŞ`¾û.•2émåïÅ5¢me­Aµx£­£(9–“«º É¡-9fb<×ÌO×ˆ%++Õì=DJŸc¼Û5E%{áF#¢«:@ä˜!G´u{ê~÷İcå­’¥,ïïŞ Co&#HrÄ¡±ÖñöÔ:4ße­,'ÍrrËZC–cÕórMaÁãr»ñÙÖ·'¾_`§Î¶®T!fnÉñv¥zVƒ^Åò3¿À£§,·(Úq¬DÑ÷àwo|¸ñÖ'GW}Ÿİšˆ‰6»÷ÉÑUÎûÆR²rKäÇäš­TÇ¸ï–Ê«<ïyi‚¯T+•'ªä`b¥Êw_`*`¾»)*`h´ñ:zŞ÷Š?&°å‰¥R†‰óâFPRš³óİp ¼Iémæ‰:æe­øF±ó›Aº½ê£*•¬uèbÆÍAÜxê‚jGK¥ı1½ˆq“[©b¼÷€fW#÷*ø¡fÇZ¿KmkPÍºfïï¾U²[×ì míù®kfväx\#®ø`vfw“‹ñBÌ|÷¶FtÍHr‚j%+·ç]ña)¨f[W|À¡ÁPì×ˆGK%i¿{LÇ6))”Üñmæ‰Ï%LŞ#@Kåòä¨ÇÊqPí¢cšyÌZ¿“Ùù¨†`ÇWñ²kv|^4FD§nIÇ[!f†`#8btô»İbºı1=›İm¬\Sv˜ÁZeÒ÷ÉÑ[†=7ı1¡y>u8|“[SlRGÍl£z¾{•ünr¶µĞ±kf“²­C0-:&—ÛÿÄer„‘rì‰˜‡çÓóÉÑÃŠ.z^;3È0ÂéÆw^;oíEËAĞVPíÿ›mkŒçsêŞ1İâTğÂ´¶õøªoÌJîy8>u>ª6AÉ1yU×ìEŒ÷œ—F‹c™4VâĞjÄã"ï*Šv;ÄèvM¹æö&‡‚gÖª‚oR:{Ïwm@‚g¯£±ò»>LÚÖ£¶õı+•ïåÔ}7ÇJ3V’c–IuÌ«Æ tŞ÷l½YëwQrÏ-¦·Ùí ß6 Á{¬Lê‰¥ò	]C‘ƒ¶õ„ĞJÕ¤Tö²IİäğwoˆuLO|k·Æ•Ê•ê¨19–l´ÜÚÖ÷œ—•WpCÑ®º‘¬rŞS +“ÒptÌÛï>÷àòe·„:¸mÑhñ|$äY=<d9¹]©orhë&¶Ş7¹7)]SKáYˆ§"^ï½Yë	D·79ÛJJ_àƒ¼]n@äy‡··)í±ò<Äh"ˆx=Ñr,“>—¬¼_P€æÓ¤0Äˆ‡bí-{½ÕÈ¤ïï&÷ÎÙ99zNa>„ .•K˜¸f;(º6Æ{şî›Ù[¨IÜFÉ=ßø
+ ·Qr·:æQr|h’áf~¼ÀPÂµ·Y t\»¦È0QÂ!?&™mİÊ^9fnyè€C+•#@AµZHa¾ù16©±ÇÊóyß/ğxÉ¤ ºv¥rsÌ<»f?´È1s{êjÄÛRiqcÌ&uœk •2Lœ÷ÙGuKç½•Ior7ÀĞA±ãÃäÿK˜Ô ªoS–[rTÃCr‹o³`Ş/°ƒ¸ñàï‡öL£ÅÕg-^`4AŞWqPíyéÇ4Cf×ƒËì#eˆ$çm“z×ˆçı#¢÷Œ aHáè—1²×sˆ™cÛúöDÖªBÎQÜH"uĞ–¯¯T!Ëwc<k“š™àrÃ@†Á‹<²_`GÍv¹@tĞì®òİ3ÿ¿âÃ%·Rİ®)Ï(¹"ÏG%{É0q‹¢…,ï3·:fÉ
+ïïÆÊ@o—)=!ô~CÄ«F|Û«(ÚA³»•½®Šxİz"9ºÜPr7Šµ‡¨3£ [â,C´1‘Ò$Iƒ@PÈäsı@Á ÷{6ßÉ ³®¥ø¹;“¯¿¯NÖÇó÷Öıİ4À£~ û‰/7$vüğt÷‹Ú§Ãxæ¼ûtÖ…A¯Ãp-äÙe‰ú÷D›Ëğ`uôÑñ¦90z
+§k»’ö>ımğ	_fXÚÂŠ22‘¤.hîÜÖVrÍı 8¯ºî{®ğXï%Çö'´ªa²i³ }=kÍÙùğh®í[†vótï6æŞ—3®[¼Kù(ıè¦>Ù×øk’½ÒüÕöoìebØ_üÎ"C7ôşMq#z-¼o÷ê"›$óÌhcñ	E>®Ì‰gVÆ:óhcóûİ±ŸŞ›Ê»ÆÍíƒúÌ0vıTz0@_Ó3¾†â‘)¹ÌüZG»Qßã‰ÚÚ_süù6‰¥ùëÊ#hş2¬Ú¸Á©Ò¾ë³@Ë´¥gÉg=V$×ãCûÔıĞ{hnlÖ#^=Í12ø×)cåT{ouJfæ‘h@è…ÄÁYüâágÿËÉßm±áÿ]Ûş‰úî¿ÈŸôQğë*söXK%>z“™{f·a»Ë‘A+öº½Aûãöç_¬-†¢Àû÷tÑ~¼Š¨3Ú/¯,êı2û~Üu}Å](c@®¬K1èÃ€ÜİÎ:ºotú´0²¸(=
+ù°°Öšß†½oeSÜ¸ğê¥Ùwºx7ë}î_ïìu-§ïûÀ7óßä·`æ’›ldÓ³ïoüç>×Ë¼.üŸbªÕ«ÿ½ŸWï7€_†2XŸèû}Õfà>]S îê2o°¥`öeäßÙéÑÜÿHÌ[Rµ8Z™4ÎY´]kG•¿Î]0_BW½FÈîàhöBûİ=ÕwºûÙAÓ»hù#à.·ü¦*ï)ë3ümİ‹Ï)ŒévîãBïtûaôAlÃ _Ä’Çhv‰ò3<L#_æ|ËõÏ=lËWY—Wƒoaô"ßIñ×¹u8¿p„aşy¹7Ææv¦ç´\vô9WÛŸÂ& Å•èŸë3Á÷œòI`C0.zƒ|:®ÇŞÇĞB6¥Ù²ñ‚ãzğîkÀk!|Îbä_îô_ı£OGıÃÌ¥çÎÌwŠ-|Œ×OÜ·<¸!ÆöçKÁœÕŞR1d^¿`İçÖ´âTü¢È¯•ÿÛ±‘oXBf`zã??^Lè_Go¯Ù8óÜIÉÓó›‡×nfîÙ	¬™ê8„Er»<¥Sü?â«ûC/Öo¬× |¯qôÍáaÁiä'£%làók¿S=<fKïbyÎ4,ó)ãùAf€	ƒÓ<WÉr’ıİW¯Ï«…XÔÏé±›Õ©s È[š­åŸalMªïî>v´L¡ƒã9qGûá=Î_#·eÖF€¾Gjƒ›¦>³ıŸXÓ	Û0\b'è¿ÃåÁ0EÖ¿6¥coí„2öôÕÿ‡ô	ççú[Y¥"=û	|w½ñ0Åœïóª»kÿIÍt6ÜªÓLş“)ğ%qX½-~'v0‚“vø8éô¸c—ó&[Œáæ…-€áºôOÇVóg|˜}&oàßQÏ„‘/ëíşØ·,‰_‚lQ©ïGÒµæÉü€V‡öµË\¾,ıÄ9Ô×+Kã{Ë="+6x­ÂÈ9Éè_İØAôÃáçnÌ»é·yv®°aLµ‹d(¿9tßãïŒaæ!ÿGpà¬Útäúİ
+à¦~"š2şh~<èxrô;,›Ê®ÛtüùÃíğ!å&u°Î…­cz¯\®Ÿ½ó~LŞãõÌã7˜wàa­=(õ"Úá¾^Î/cßí7ß¬ƒw¥o}°9ØqkœW$CQÌ^’´më?æ©ıôarù¬	nşÁÿär‘˜:®;&{xuëù«œ® ¤ÀézÆ5::A¸ÃM¦åANhêÎ†>£vã`ÒWœ>fÊ!±p"ÜÒø)g3|Zôàã·zG=C¼ÓX« gÈjì;ëõô¾ø¬ ’>« ğîº`¯¬wâzWpYx‡²)í%àıJêJ~
+o6¹\=¦yôç»îğÊ×´:È¹¢8KÁ/ÂaçÛwÙE÷àü\ôeí>Ş¡/¹å<	›qÄm±}Ö©DVLóÉÕ<3½Xî_ï1ÉoA»¬mİóèÈ1Ì™¿a;2NWn”}éV¸P†áÁ[aòs{zŒsÈøkæ&ºµÙy=ã¹¡ÿ>l¾ât{òŞ %ÿ—Ü~¹á—¹«áîf#üÂ¿¤vuUb§7ä“Ë¯ÚÆƒp·4.â3÷tt5Áíğ…¥™Ç=ØY¶GÜ8=d“åöw÷6êv+nãwHÄ{ûZÍ‰´ì»óùF–x;è“—Ü^èğŠOÆ8Ö×Ø¹.Z˜ŞÁd`’ˆq3ÔkIîÆğñx-@/R¦ªúnÃoówÉ—¤WŸ$ï7û•vùO4Ì8$ÓÊÎ+ktA²¼u“îÑÂdóë`İ
+è—T•î‹ıÁ˜'3ìù	öŒ¾ÁNÑod9eL¼Ó|³à½k°ÍÄ}ãOì:İØóM•yk`„}Ù*óïô¡d¾‚Å¹n¹¸°–¶ëèo{€œğ@a«tp‘#vàroe·©H›áPÏÚnş2£c&.v~±Jù7¾ôîCE÷ù1á0wÓ¯)ÏÙİ"½ŸúÓû–GFí?¥&Ò»	wIl“x@¼Éáé'œÕ¤/.<ã~ó—?Ü°foşŸ³5°®pW’3št©94>)ÿò·{âØ¿ûüÿŸk¿ôN19ªºõoÑşó‹ûºfgÈ³‚=:ïéy»°]hŞIÆcXÙ^ƒöÖ§®ØİJÚÀ;­N¯#…óï—È¥Î_ÔÙ‡Â*†±ËS³—Õó@¬\w ÷aŸµóıyùØxhû!è§rø\!ásñin^6BS­gù–¡Gƒÿlõgô3öÎ5¤Şµñ/ïüÜX½ıàÓÙo›ø°î5ÄY’Ò]Råœ7úÜpâkäó´uCïõÜuÕ[é>ãŞ{˜Iætİ‡|øÁÖ)¸3×Óøêz³´ëMüüîutœÅ³°tì1]; ?úPçySgbw|VvüÖıÖüÜgëzÃ5“ËœâKâ„ì`Å†+òëloŞ+¿4ı`QŞ¥Á|0@m¥s¬^¾¨¾?Åıt2n…h¾Ï«ß¬jq¹§–ëîêú|Ämøò%Sl{ĞxnÔı›j¿*ş®ï7Á;ãs3‘İ™ô½:ŞÃkå[üä|Õ—&ØèbM½Iû?,—¬Yc{D”ç¨5A<¾»öcš×ÄáåÈô¡ûXNòÿõÜW¦-È9Ï“Æû©á’á™›>æÃ§ :N.dßÍNİgÊl¨¦§úàÖ'ïƒvëqÈ|ÆøÆ\Õw¯İzh|çFl¯¢{¬<qØ˜æç¶ZîûVº@öólqCÑÓp¾ıß¯è'¬à ëç¶•ÿìÃuÖ´š€Ìğ:Ì›À@Í’íKĞS4µİ×Œí÷şìj®ï>é“ãs…yÜ—Ã•Ík|·Æoğía&ı÷ñY°ß9³cœ®÷rÈŞËjâáç-À{l×Z‰fGhíûızÿ–1mízw+±İ¯½ßBì&+KGıÈÛ¿ßÛvØÛûŒ¢?É:vNc*À›7=hj×Êô|–ÉÛÚö£OŸ2¿ÿĞ™)Ë[¾x@~>Óò¬©aÿŒ—Nl"Z¸y}	}-Á³´ŞòZÌ…›ÜÁ>X	÷‡òLş	pğ‹¹_¥İ":KMÂ]+½÷›cp³¬~*û‘=7°’IÿFŒæÀwºs“åIšf}ÀoD]vÕ'íö¨ÎçÜêò3ØUÈ)oŒÀLv‹U-à‡M
+úYÍá½c§Eß„XW:ÔsÈÃŸİ³¹ÍÃ“Óí&Ó¡ëâò@İ~ªş1_7¶ÿD2˜çë\ŒMMÉ™ëÌ™tû7Ø{‚´¦ö./Kÿ	…ç8~¾ûÉçèüñQ®÷æªi°MâÓ1ºtYôÜAào}5‚/èµ“QïNİ?uûñ~}2ª×~'Zøïğ›ïğ!\FĞ÷Ë¶ˆx'qñâ…üÊá§/É…¹o/áß4ÌH»üÓ§©Ù"Èé;lŞX„£n¾bp½ ¸~A¹ŸèŸo­iÓğ©qÍ`Â]tO{ø@½ıÖiúGà'`!‹öº…:éŞù<İÛİ‰íD°ën‚{Gõ°şğA#>ù|U¹ñ„£ÀáGÉ>Ê&öÿš“c êsëÎ›ÿ¶Ú#¶¸¦W©)CÉ¤c±YCÖPÏCùSÊ÷x;¹çÙ™ˆ_ú£ÍòÉmÙ=¥‹·3ëõéßË_üí MáÑE Ø¶ñ:ÚŒ¾ddOş¬wª·8ì¼\b›gÙô¨ÿüÁ@¶şüBşÖea›ıñ“ç1îésCÂ‹ñ<·³Éá¦”cúBô¦‡§0›iÌ.¼gÂÏ(§|f—ÉøÉ4…Å8Š±%YR¿¾¯xrçbóôuE–hŸ¼#£7æM_Ñ?Ím_xÎõó§F×äaÆæÙ77{ØMyw¸µ«/nˆŸº“Ÿ½’Câi1ª?2ÔÁÀú;|O|<$ïGûîÇELÜ3ÿ¿wëkâ1d:ÛEOÄO¿‡ºß¿ÎŒ°G8±˜Õ©¯9·93÷qmMî
+6Âëõô‰OÍr–ï|Ûwñ§áù¦oŞf‡¹»à€_Jy:şs/öä§úğ³r‡¹StäÍ¡‹ú3šÂúÀ¯°}rg´‘kÒù•~r	šÚqèCàÑ%¯êßâ:x÷¶¿ø°y´>rB-pÙĞtşé¿EŸ.Îîœ¡bôO-ı^Ÿ›ÿ‘—¼ò½»_ÊCÑK½@˜?ìÜòùÏÙÛ|ôX,ÍÕsk×ê„¸x'/ï{èŠËóiØÂğu«©;y¹ºÓBLK 0    blsc      m      m      3p[k™cåœ(j˜È½ËÎÙ¸  i‘p3  p3  i     Q  (µ/ı`p2=º ê Y+u]?ÀÉ,ùç H”-¦ˆ¨ºŸI$nÍ&œóœÒŸ÷|gÓæÓİ˜=“–¦'q.q6e}_.ıİÓØğFñ-x³(3iƒ­yÍiÎ¦iÍTå1fòåÓE±Å°eÒİ„-—4Ğ˜GË¥ç‹)—&ƒ+“$”mËcåñp9Åšr…±LY(O6MG,ù†Ø#Sß³û\‚-9My¬\IJS®$	éÉ#eâyZ2zºƒn|5>G®Ÿ!Ÿ)/¹$!ü@ìğ°u·xÀòA\A>=ªËÇ–ã‹±L,K€¯Ä×İ¤!š%—¦o†Lú9;8?.½y¡ùñhùæÄ§€EÛ17.ıš~Ë‹/ÇaF(ÎÈ¸zûhƒçÃÖ"óáy÷eÂ“ñHpEø:@^Df,Vüâq1x‘½ /ÖêêkÇ7[Ó
+ĞçfÂfqëºå@fQœ W|-·Â¶ËéUğ‰ga,¬æ‡±Ã_Kp2ƒ‘Áp+PX€¨fHLø§
+Ï«·_…kÁSü
+©ÁÑŞÖW›7Õ„ÛS‡U¨¸{Íy®–¶¸©oË;muë:FÛZ~™VŞ&ßÈ×ôÀvêpñºéW¼}iˆµ«§IëÖm¯Î¾®ÿö_y÷õº^=ù8·õ||Ûú>^¿šÆ¦fgl9·¦SŸmı±©R¯S}zôÛšSˆ±O×SÃØ¤íØÔõ¸iùüšÂ°)¹¼´ı;»tı^]'ØÇ+ÒÔÔòÑ‡E?õo6=~¿<ş?ş”OŸ~Ééyd
+²õx·aĞ£»³I“ßC‹îø*L$âÎ6=÷ÎŸÓM“¾;'M·›-7<}ÿ6šş=z>øA×W‹¦¾ıÓ«íÚ¡G×›‡{‡†Á·ç™½İîÖDíğ+˜‚ÛéâÛòY¯T[ÛÒíú£Ó9™bØ“»b_Ú×óN»mv63ÑóLbÒsé¹æër·L=Çz –
+oßÁà\8·éÀ÷Å¤)ÓßÇqÆØ4Å»_u\½`•%Âw{İº—f9åîÎ(÷~ººÚÍuş®ÚJÍ¾¨,œÔY¡©§DËĞÖô"m‰¦BË·3Ÿ*—ƒI9şxÙ=›®{k?ŸNƒæ#ÒõèêEWãÕétè
+´]}®DWŸ)c`Î¥öæñ©ÎTgËº³ì„*Êƒ¹“™3Å™Ê¼çQóØ£™Ê@¾Î|ª|ÍVR³Ü,7KÍæ-oa\q<ù¢xWÀ)ÙìËTæ
+3EùÊ§JdÉKKWdy'-ËfË×à™-ËÉãD²8ò¸<qä!S“¿$_gcódSÀÚrÏëõË‘'dÊ±õ˜b,S¥ãéûBZ±ö‹v¬}÷¬ø¢‰³Ã+3Æ ÆcŒ1Ç|N€³¿AÎ@ˆ+âë05Œ
+/–
+lÆØbl1]LSÅXà‹0İ,n¦ÉÊ‚ÆÂ‰'¢P/=û›³ÈÄ8[nY¬.¿­ÀSü"|!ÎgW×ôSo¾—Áçâœ½±±1{cÜ–V¹Ûò–Üø^â®Üò¶°›0õ–WiGßü[³İl—wk³\¿2ÌÙ]Ú©ğ¢&vIÆ,»]=Æè•6¦Ø~ÙÅuKRºÚ4E}>mÉ¯Îce®é®|]=Y>MrBG“`Rİ„¸Ô˜r›‡>ıímL]ı}xtè»aÑ§í÷Ë~~Ñ‡»â-"‰Û³ïc[ããtt21¦ÇÆÖ‚°ÜZZ¢Ä¢K¤K!Ç¤Ç¿‹&&™6‰¨Iã¥ÇĞãèÓÕ–-¶İ*£/[çnÏ•³Ës8àëyÃ,˜x$¾gÌÈ42¬AÎ$ÓÈ4âÍÙ2¶¹åš'œ!“€écÏ1š—ñe€au\+äíNsÌı–xK¬!Ş^öÖrˆ7 Y¶oÛÁÚag¸Û	_ <Ø3|½´A$^Ãmà˜·âZ¸X||ßÁÜ[CáíğvxûØ†§[qmÙnk9ÎİÛ·ß>ğ¾Ùp0PkĞ¶„µŒÚfÛûÍ¶v»m“9É÷ê]µmÌYğÀ¼&Úpì ·Å¦v±ÊÛjoÒíx[ãÖîµ¨½r6»ŞšŞ¶ö½ØôŞ³'H{«]wöšr˜©TMRW©¼JÈšÕÕ¯jpµ½mÓ‚+Ü$Ã¡üÃ¯¾:ñ4!óØólºY§ïÕúx4³¶Öö±fJ$™u£ºehQŒC„«]=Î:ğy<ôÚb6…e¶g‰* !Z,İ}otág÷jgÛİ•Z¼‡5{_oğoã)­6&Ğ<§Ø‡s9q¾çpwÀMƒÕht•Á–¹«#“"_şş.,:ôüî™«Ïßáˆ-sŸ¥çéùâ,±Ÿ¯ÊÕç±çóWyf¶şªÏ4ó³ÄlaW?Œ;‹š¿ÎÎ åĞ²\r”çeçë²Ü|i¾(S“)
+À•GÊ2s¯|e¾*SË˜ôå3æë:3–-1I6# +Ó§˜­/…yJÎ$ÓÆöi¯Ù¢±¢pãË±U,~œ)¦Œ¯?ú4ÛÖ€iÀcí·Ä›âº1€b€gbÊX[\ÛÃÚá1vXûj	ÁŠ+c¬°-¬Ö×ÄYá0¡ğá,q†XKlX'®WÃZx‰Wñ¸®bíÆ¼³{æqèµµí®]·Ğ%ƒcÓ¬z×ğ­p½gŸeõb§v‡YÊv­~6ÏEŸ¯âİöµø—”ù„¡áèÁLJDè¦­rÕ[éLtOß¤C$Ê‰?ŸCĞèzwÏÖó™t ´z#q Î§ Ë)v Ú¦Ï:ÚÛĞ;¢ºhÃö;Ôµ?m‰0}ØŒÏ^ví:k¡3Ñƒm5­yş:wOğ·Î‚ÎŸ'³ 3³¸Yğ›–ëfÄÕRö6–íÒZèŞ5{€=2¸½˜³Ó›µ÷ß½z›šÁ“AÊvíd{§Uî, -_J¦3eQòwy`¤,R3Ü$ƒ‘ÅÉÛt 9 Ù>Ş$”¿çö˜ƒB8?{5Ç]£r`ñpøø-ù›ŞÆaÄëîõ[Ü-”y, ~l8tHd°ÈØN‘‡+¨ Ñø[~ïám(ö@†¥úğÅİâíKì)¶C8|{ {Ó.qg8|…o`Ìşˆ;Äİ]w˜;Üş¡ĞßWĞ¹pÇ‰ßeØ;È¸Ü–Û®§¹Ãxß8·4Ôğ
+¸²ã¤ßi§¹ê	Áo'é¸à¸ÛP›—À]İs® 7«)¯èÙŞ6
+®Põa˜?:è w7%,Áï×¥÷¢Â¹ˆ¦øàR®=ëÁ”[^yxZ°e½`Zğ¡¾…í®;ë;"ı¬¯¶¢oVı_Š³QÉÜLš©¾£;ªR «bÎ;[Îã÷bËÒ£ˆÛ³WÚ=è$&íW"(ø.Z°A_$ùİ]¼ÖÀœ­?ë46nCÛÏdeÒ[åŠùÂ\u?û<Ğ ŒqPg¶MGÓÑØçŒƒù³ıHöTîL?ƒ)_×·£*ZËÓ²µ(®<%gW æÁwÁ”kgÁd{ùê¼Q&ÓÊÙ²~kfz9ë|Ş¬Õ§Æól=[Í Çñå“Ùz¾”3ÊÚf¬sHÙJ®’«däù›ŒM_ï¼L)\§t2†r¨Óğ è( @AA’BcS@àÀpPL6!¯~€À8ã¡mêÔ­WöÑW÷–@©Tmq·›:5Vx÷N%Ú9Ú¸Ú>èxô»9/û6“¿nZòp±¯_¸!‘aº½ñÈï§z3N`°i´=I+çÀ—Â'DÓê„ÔN·ÒÔRÔ¥Ÿf¶Ì©=†øÚèvFmOò£Ï¦^¯³Õö-Ù›ò8YYj’Ù4ûaÍlºÉŠÊóíºb\Ùr{ ~DEè´e°ìş0 µ¯gÆÁÏ¢˜wÒ4º«óšA}ër¾µLÒß¦j'Ùc)aå1g{ğe~Òä5Gâ^<›ıèÄõ&Åà¦èYö¾µíUVÒ«©rœÕµlÅòıî½ñÇ$‡×niâ\…ıÒxs³œÑ!{\æécU4OÙï½b±¹µ©Ö€³0ÆÄæ¤<Ê3Îæ'ºÉYë²¾tŞÙ”?r‚…ÊâÉ;r+;W¬·M4^å·¢¸lÛ“¦4DÁÖhğîŸl£:ş;Şò:>C”l—GNöÒğI;¸j÷£;¡ÇÔãÓã–)é;‡cLØÛA\èYø¶³xòS¯-l7#˜œ^Œïv×4µ¼1â§ëíuŠƒÊÄ}±Æ2_Z‘ç°I2±¿ËW±ÉiÜÓ.¶å´ù¸rtÿÉ6Îå:]±‡vqÌ/”ˆİ“«{[¼´!1_mëÃ23=˜9ß¹Cå}ùü“ˆæYTÈ=Q€ßu ‘}¥ÜE+ŞA}oõ’`Öõgu‹ õ‘=íp3íç‡5e»š:ß“RŠëÑlF=³Ní«İ¨h™OuÕ Ã°Ò7PIîæî‹òdL¹\8¹gc®ŸPóá-Rak»{ü˜WÒ„80=_uìnñ®§1Øh8›ÑCÇRH3s¿œ¢/9-í¸ÇàùÃ)ú@®·Í¶ÿ­€oºŸÏÒ¸8ë%Ør£Ávõ§UJ«xÂ¿uCé®ş¡­øÆ§†´²Rÿ‹PŒz)ˆuÿ¾Ö¦öÍ´œnÇ¥Ñ?b+ş/¬­TJÄ™öVk3§Ó¾cÍ¯Îki¨ûHıÿ@{v;ÖW¦A`ìÅÎ»ƒiq­oÅÅ¹üd}VÏó§´Rp¦½Ç€Ì]p€Ÿ[Œt;,ËŒ+İ¶ØÒ\uÑFmãÔhÍ^`#¯áí…/é°áü‹BüY1[£ 7è±ÁúšœF>gƒm÷§7/8#aÇ0´‘¾©	´.wZ·!R§øh
+‘'İ¾RÁ´)·—mp´?ÁÔDC~”#SaiÃ˜÷ñís%@¸[yÇôÑl¶9õ,ÚK@TQ_ÏÄÈöj`hØ³Å¶\Ëõ™Íõ[n@ÿ µ˜Ü,
+GÛßM@4•¾úÉ“Ê»˜Úk¾Ëº‚à …Ã;ST,)Œ_©^´"£lÖgŒï;{‹«Šµ!;­iœVhËtO4¦Ê´šEO3ÃÎæLçÿv¯>¯âmôÉAààåOÏL,—c­O”W§äU®QV²ûÖ[ëàãˆi‹ôM!ŒLNK"…Vòğºbëõ˜±tğ›’ñÑ]‰í#pf5-.Foù]²>â“ûS;c$³›mmäDÂìËã²­{V§1^ÆŞŒÎÙ¹F‘iÄ´èg™.jQæ GÛ[Övüè3 ÍîóĞ0£#±,|s'ÖQÏ*®+í]¸ƒ9íˆ®>_AÎ]Æœ?©S¹4¬•òŸö=4Şäòçv¾w³ÿuL@¿áWúåÚì1íe¦Å×µ‡FÆ°û²T„¦ë¹ñOö¨+šÂR†°ú%1?u±:¥‘>ÕÎl5flzpÇÃÏÒùH‚°b³://²×g6âTÀèŞÑP2mwYtgó›ñn;lÁEÍz²ğNE0%%åµˆd²ä2qí¼£M›šÙs›všØÀ¶Õhß‰ŸPÚŞù!J^íó¬•k2ªá&¶B_Iœ1ñ6[ó$ÿK–Fc¯QŸó;Æxq[,î©pl…u€[oîÀŠ¤S|ƒVâ”‰êw=ÚÚ¹ĞÉ-r_šEÒí¹“_`¬Š.ÀFz—wC†‡Tì…}É2D¨âW›É¯‚{»z$·X›ü”|U·'¢½s†ïnÊ2…CæC>|Ú@gÚİ‡æu„!`õvWmÉŠ¾5ÿ•ĞÌíıUÉo½—7&)WRjf§ò¢\ûûmfq1Ã­>»*ÿj™ŒAŒóbsã|–céí•kknûín“ĞbL`7Òsnš´¡^«û!å­9H§5&®CpÅ™µıb@ã'ézIo ‡•ÏÓÍêq½]Û§áî‡ŒƒÚ•İ‡[>"¬T÷rëè:uôéÂ~bŒ:v7G°Jí[ ¦ÛEŸ&oúuôvF³xÇÆWÙ«À¢Ø6G—gÖÍÙ4ì‰ş¾áÖôÒŠ/şÁõ[Àß>ÃÛ¼Uµ•%cñmøï²±’b>>…İ®ÒmOsÁûÀ~øŞğú²ÑØkèÀy¸%XÇáV@´»êi)w"Ü¦Â¢8P;‚â`S,ÆfÛ4fıNq1D^+ñ2È†?¨M%+âšRÃ6JÑ±é+«\»ë”:}[zÌØŠW!ÍK­–FÑŞŞ‡ícnª’Ú2æ³oãñ°ÀRíù8tÌ»ÚÍ„×L|†O ¶VO*ƒödh2‰¥ß_¿àşª1"W…VşNß4ˆU¶å8Ö=8]{Ø§3Z@³ùœäô°RÌéÃ9Ä/®8¶v.#—ífU>á¹?ĞdRt·êdÀ¹Ë²÷Ç¨wö]÷ª<Åÿ½XùıXóÈ ÎÓŞŞš˜ÖN³rff{=Ş0–îÍ¬›ÌVİÌÌŞq+’èÏÚÜÜVd€!q¾.y•^ú„;ÀñMúÊàÌeM(fà~ÁÅõ’¼4Û ¹ú= ‹+‚öñ1xfëŒÿñ°SÒ•Ó®óÅ÷ñHbÙ_š°­™ı4ˆ›¥Tø‘á“ëÎñ1¹B{~N0MŒÈEk»ÀÈ¶4¸Ğ>‰pâÆÆK0½ÆÇåù[ó€7H6´N“ílŒ>°V³°q,9HØs6øäñ±ÔöÆ2™õCŞa²ËáSkItCXfŞV“÷bÍvwØUw;›Ã9¿Œ$ƒ6?<gğLjãh•ñmCÉ2œ„Ls´z5Õ¼jé‹Ë|xzZÖô­Æo7Nçi<»RI*‰_CòĞ"&pR¶Õ®k«M­~ØL8”Ù½É“¼wı»±´¾E¬éw‡D–	¸~%Ì”Ms.ÈşÆîblÊÓŞlÈV¬wùH|qÄ)Ú§c¿İÑ LîÜĞìdb&Ëz(Vfœ»¹,Š§Ş¡‚=µêÀîxSv	ÕqihT9H}åÖÛwÿàöJÑ@mƒ‘¿ûm#,¥ûıõ[Ã¬<-ÿiíº~RÅÇÀ¸šiÁƒÉÌrhØCgu™âD>MÌxÃåİ<p%¡»vvì¿q 3‡xµõj!`û³¨cÎüh¼*U¶K·€¶\ãµxÌ©õ»Kş‚ÛˆXB·Ÿ…s_ëİİæĞ5ÿ.ç–‡ÔV8Şw%s*ù¬e˜£ïÙ@eSÇPğÂØ™LÌEñœö#Æ:Mz@ôÊ6Ó›æî’-¦‘LÍ±ƒfê7b°knıaiP8vMËÃyö˜ÌÓŠÙ©lÇvO)fm!lKK=‹j³É’UÏËNVîH¦ØVOÁ9Î92l’ÓµLÖG~j1+Î»¾›ôÆßÜ‹…Î}4^'­|ë“œ¹1Ã÷dgÖIİ£2CúİŞ†83ßr‹Qj-E_eú]ø3\î+l³Xsÿƒ¨yô%!£W]ÊİK„MŸÏñ0U^öKŸ!Ø*›7ıîOê÷¼«Y!¹éÜ§ìVh†ìb>˜JÛ`Ch(Ñ
+ÚÄÁ2’Ö2ü8ˆæÁì:Ô‚5xmçªÎ×ÆKşšr‰É¨ñTƒÖ}2oõƒÍºÆe³2âÉ~ÙÙd­§;…±™uXÈëí?€`ÈGÃyì¯sA;eDÙGhéÖGçºsVÜ&Flßb\L_‰«€s[´Òˆ±Ñİš3'm¡Ú[XxM:é:-tú Í»k7®ÓBLK 0    blsc      Ë      Ë      3py1i-¬A¼ÒK¬¢w}  Ç‘p3  p3  Ç     ¯  (µ/ı`p2-¥ Šúd&(r]ÃÏ¬FX
+JFBß˜”×ŸTQ]wIz€èÒ}Ş¥õ$#)z
+-…G‘ø$Ÿr|RÓÑœÊ©ğQN½øÍ	…UOáq:-}îxçÏ¥÷lIƒ>{@‡÷JŸÆÏ1\¬Æ†|ô€u=ƒ>ƒÂCÏ¡CÇÏâfhsx0èà`óšÏ,j… ƒC‡6‡–C—Æ•C
+ö2xÌcşàĞàsD9tÙcY´<V+ƒ*‡0‡—ÇÊâÉ!É!Ê ÈÑä°òHyœüdéòX9ª,J#%ÁÁG#“GÊR$ôd)òˆ¼äqò¢äOdIòY6'‚¥Åd9ùÈ¡ÈŸÇ;OËÇc	²øX>–'Ç“‘X*–ÏÄòrü8´x|üI,ìiRüY<ˆG%Ær`	@3âi±1e˜bü!,ˆåŒÅ‘âÏ€çâi±\,¦’ã'Ç“‚³¹€Ù0•¾Êàó;J,KÅóğ$ğ°˜
+L=u˜zà1}š8(¸;ê¼'ğI˜ƒOÃ³;:\'¬KÂÔ÷ôºß°¥k;Ò–²'ğˆó´iv.OÙ÷´‰×ËºlŸìSEù’Œ-YİöÑÀï·ux=í!»DZmû§>¯éj‰ISŸ]O[áô(3]ROÔ×'
+ñ¶å!ñÏtL	Wè ùH=(=’ËCõUK £Ï£ßàĞòø?YŒˆ?Áäé‘Saw‡As<Ùõğß®uèxôßC€©=!÷Xø9biÏoxŞù®–~{çÏ¯8Ü§ã«ø>®Š+Æ³ªêÀÕÀ•±½_Š-«ÀTâŠ±]l)¾ˆ-â0EL¶6ñUl1¦õğ= l×Ã•á‹¸&®ÛÄVàšØz€­wõ®ß¸uØú¶@mK›nWìºMïÖn¯-oËM»iµ¶-ïë°…]kµ¶ê”²ô~ïÖšvßìëmu_ÚVÕ¶´í÷ôxÕ}¯%¸e·ÕµUÑiuE]«)uE³-j%v¥}ëõ-êJIÓq*Ÿ¡©¯óIM£©qNÅ;›CÑ5öt è(œÛªS\¸4şs/Ò[æi”2ôˆ};‡ —OÌ²u–™¸ô•sÄ9ËHâó›gô$ÉÎS'<ò,;Oâôä9ê,Å©ç<‚bAsIsˆyÜ,ŠGœ#êhé³$¾4.‰%gi³äYÚq4‹‡6GG™£Ì“æHf––4O™¥ƒ£ƒ£‚×hsTğhy*X”(KËãåó’Ä,–KÌÒå+•GÊ¢ä9Y¢M–—#ËQÁÒåhò”EÊG>ŠM	–”eåñòTyª,%’È"Á#ÁC$?'dª!9plLAOÆÒqôX:¦ÓŸ§Â³c«xV‰+c*0mL)¦Œ©ƒ¢×y˜
+Ø
+x"® ¦ˆ©ÅRñdLéâjqµ¸¢àÓp%¿§Âø,L®S‰©€)Àµ0ıº%ğúM»%÷N}OÃ3à
+pŸÔ6…=»©mºM³';¥=mËì©»Â–r[jWİÓöD½)Ã•Ô–·šZw‰]OÖ³>ë[Ş#oj>İéÓù¤Ïêi
+”«uÙ*°\3[ƒ­e¦ÍswğµÌİ‚¯flrl2{“ÈÅlE¶æ$ÓjùÛ’;¹Š\I¶$W’«Ê—^–/æZ»(_ÊÕrUÆ®ËÉàã+)‚+‚+È5rEpE!WÁ—ñ}œI¶9ÉÀÕãÍ±8ÃcŒmul9¶ö±eA¾¬ãìJ|%¶_Œ+Æ–qe|oğ…)¾‹-ï+¾…­°Føø*¼ŒŒ||ß–÷ÅÀ³ïÛzßWa,œ¾ ßâñõmŞü~×w£}o¶Õ¾¸¯÷Å}»1â}Á1oìãŞ_Ã–»¢oıbcõ~¯+»bÛV·E8»Sp¬ûú¶×™·EX³/İ^‹Ñ/j¬Ú¢_ûe±k›m±¯èÏ~İ³[¿ÕZİ®m5F¯°/ì¬Ê»êkÓ¾~®İ¹Å>£_êZÉ+õ%måVt%·äVú’Ûi[ıy…›y£Â	•úÎ÷¶=Ëq:·Òó7|§©æ¥¹N›6oğ(]§ïô¥ÔË<_iú”õF·µ38­…¢içiŸ¡-õ–}3Îàæñ7ºâìEkôë^ío„hËÊ8¡†·ù£_š=ËVİ^k†ÎöÅ¼Ñ·ËÖÕYÎ-53E=j9^¯<3áİò'gÊÙ’•±Ê½–9fóV°ÄUÎ6KÍ”æy°¤TæIYÚLÍËeªàIÚ\,ÉËÓå){›iæ3—<¸«ìU–ÙdÊ‚™:°,˜çäHr4Y¢<N–OÊ³àI¹ª`,ÓILU ÓIQW”êò]¦"×ÈUã{ëbª¿gñOü›¾ŞFk_ø‡AÌ³÷¹P'„>¯3˜]¡«gkÜ“6|Ş2ÏŞ·Ùãœ}ÀÍW³r¶œ¯®óš ŠƒœœÎ›Waœ/çÍ`+»ŒE#8<§Ál7Ûp„Á¶3áAÍ[×2ÛÎÕsÁ
+·š¹ÌZw2sš¹ÍÜeïòg0¡²ep@eËà€»İÊ×ò5|«gÍÛä»\3kpÅŒe†u›ÁÌÉİdBåÃu%ßÉ–²æm•±ÉŸämò™³\¨ÜMş&{³ÇÁWdÂãàOò¹ Œ<¾"o“¹ëqæAî¼ÆÛcëhÜQ_{\—e9¬±GğuœaÜbmñ–8S|a‹•	†Ç {šbOøc|	Œ;BÖ˜kÌ5ÆÅ[Ç¸¸À-²Åf¯EâM±§XËcoo‰µÄ¢°vÏ2Ã¼Ög€¹Â7FÈ|XË¾1mCÈûŒpvmcÚeîmã¾º3o¬[Ë¾{ÀVXÓ²»ÂYt]†×ìn-³Æ8¯ÓÎ,ÁîÌf<{€eİecÙZ¡ËŞp°&°·ûfİæ`õFÍÑ;k«î´jÌeko˜îæj67Ğ5ú£{Õß‡°èÂ|›.Pg˜Ü'AÂ	Ò†¯Îşğ˜6×&Oå…¶ìçë«ÒÜ8Í½wiÓ–^ášgkÚ~Æ>k×Á3â,–(¹½£Ë¨y½u.d¦ ·ÏRdÙ’Ş3á³Ç	İYƒê™MGÎÕí|=Îè‹²uy^–2us3½<7o—V}>ÓÍµŞÍ˜¹ÚŒM“+íF®UeêV–(S‘kw¹0ÙÊLX™¯+¹
+†|¨³ $˜J;»H‚±€„T³«Ê€À®ÂÇbÛÑÄe¯Ü†û³èDçkN“c9JòÎ5lGK&Èø.şåß›À÷ˆÉ‚»Ñ­µ–ä­`°Ù±±D]¯pÌ²ıZô$uÎ®éÜ´“SnÇÀ	SR_Û±RÀâ.$}gÓ1_ô;Ìñ	¹wö7Ñ£5ddÚ~Ø/gÍ
+±µüí–İ*{P!Ÿ?{¶…Ëç|
+£}ŞÑO#—¦ Áµ®q¤¶´Ë0h²¬÷ä0†üöª³Ã_|mé Ö9Ä%±t½Ï8ƒcëÙt&…a·-ÇUª­SµŒùèí^uôêÇ¿t’”µÁ’lÏ6—ÀÍp~n…Smo"÷ºw|7…1ÉìcÛH¾¼M:Øê^›¹Ê.úL»‹Ç;º€>çnÍ°Y0æ	÷áÕíCek,Öış‰¹DÜÚ>7ã{ø–WÖ»%ÛìRÛİoÆ†‡S/†3/³è°¹Õ>½…ÿ³+Â§~zçÅivó¾ÛOCÌî¿açŞü×ÓÓ:P}À&m ¸É–Á-¿œ~';{Kºıt¡}ö™T7Nc2:Ø^N}â8‡‰ïÎ¼-^åÏÜxíÛ%òšø3ŒÉÂœ¾vÈÓ¾p4‚®vÎˆb7R:ÌŒ;À’Øİ¶‹(I;(MÁ¼j¶œóqÕàoíÌw[Ñi`ÈiC/™ü\V¬¶æ	Ã¶Ás7e.À^ø„ĞæF™S¶9å;ÎÃÿ6x'Rhg€·nu÷å•DÎ€8`J^ñÔ1\wÔÎF6Ÿ?İÖ7ÊÔ÷ó;·|Ä1qŸfÛì‡ÇåòešŒ­è*m!Û†Áw%ÇEs®VóqÙö±Vœí><×Æ¤mÊ^ZÆÈØ”÷SöŸWf-‘+®¿àÏ±¶-óWZ¬¥õdA¬ï>‡ïÙÎg}bš5ş™BxÕ¯$°l§Í¼×ü‚Ñ=È©ˆÖ¸Y!ÜŠì²qÌ­Œ)k·…5ÓJ‹uã¬I‡‹·†]êâ¾¯5CT,+²%/h·q.wc9`6+»ñGÑE¡™X‡òrÃ,ÂÈyè;ÛºMÃ³¥ÕÍ¼•Eß"£™µÁAìv&m¨!ínmÃ3¹õy38¼È[IŸ,§ghİşÔëBÕ’wxÃœáænÏmµó¼ì3OÁ¡`Ïr +‹0«ôJ&‚ù5Ù(´p$z¤»“×!f[øSRƒÔ9¼íºô?¼6M×Ã;9ÊO@, ¶ÆëâVoòùšñ yŞ ™w†S’™õ©ànœÏ£ÁÀô¬ŸX.š×}•5ğp/ÎŸ,\“‘é^Rcì)Ÿ°"ê	ÍÍn€ó¾µ²î¸)Î`ÛÇÎ¹¥YGo·Çš÷§vxœar×ßU-‚gõídx·7;:ugªí>İ¬ÉÚö¯ŒeaGnu¥Xë ;:6Hå³L¬¡/°Ms¾ÙïXöéÊTê<}u˜®c´Î=¾eSy“Ó=2LìmRÃÃö¿Õ{2G}kë([xgã¢·~„ÌıõÃöºu‹ùµ7â]óFÚXë¿•d‚éq›Ù\ÏFf}zâş¨h×›òN†ô	¼ƒÈ›QÛY÷f`TYå¦v4®yK1–zÌ;ûv$Íh­#ìFß]»ep4»eÚŞ1õJWYÜ—¹B·AnÓ£c³dËvËòË¥¿³éºÓS¡ï­qK»6¹¢÷¾Æâ7%ùíÏpÊ/²9»H“òVáG=»UéÕ&ì2O0JGßùÉ ^ÅŠºJ·°ıêS;ª½s-£;Åÿ¶·4q…'Öv1Zz{ìwuÆ,Ñ¡m2MR•Û;a¥bT¹g|»k1';½8Ìâ-ŸÄeß·ßÑ•YwF¾¡±ÌœXs†fKjÓNÜpl¾ñÿ>²İzÖÌ ,3$Sp,{á©Ìƒ°­CZœ{Q‹±Ëo¬ijcnî­:¿{Ú4n†öÜà=y§LrÃğv~.1Ìój¥®†Ó(~$È­wFäÉÅ8ÓÅƒµÉ›é³ÌH2Á–ëıBäÔªÌ6pïN[ÀJs­W­c2¥[°Ë^ÈXñ*äÃ0yfbíp‚•Ì¦SH[Û³Ô~û¡Ì:ùI»rç½Ü–ÌÖÁØJñîÓ·>Qv"²ÉƒgĞ“7ôEïô5jAf:-?#Ù:ûòQ½n¬„C¿Õ»ÊAİÄ›=×Q˜)l'©ù©óvpÃ1äõÕ±`S2JYÃ”‰Çt¶ĞÕºDov´÷êÙx`Í¼â;˜‚[û&ÜìŸLù|Ùnëq“ƒö€ÈÉ4°Ìùt9Ïp-0è‡¥‡PÀÀç„GãX|¥êÏíÓÛ1hQĞ²j¾ºño tVhO„ÍãeÑ³åoòÓÚ ˆI¸¶¬ş4vcƒy3×ÒI?ş‰À¨»Çf÷‚v0¾.@ÖFw25ù[Èºy:ì4¯<öÛã.5äÆ˜iñ‹ç7yvŒ;#«	_u€2Â½	4[M–z«¥ÅîéğNàğ’Ğß›³Æ:´ÑmXE{azs³…ÍU“½¡lÈ0ß£re3k@÷óHXÜŒº©x“âæ°ì¼ñi A¿¹¼;{`P6îŒCEk‡˜¶€)í4Ä}“Aæï@Ù~,ÿ†è0v©ˆõ¯ã¸0Ÿ›WÀ†Ü±[^>ö	ÏÈ=‘’¶>Š§µWWÆÀÌ»O†•38µº_·…µÙz‹{6—éóæğ­Õ¬eÁOWŒ¡‡é;-¯‰¯ÿ¦kßyq[Üzì¢Î§63	
+±†óhÚ‰2Şsß›ÏëÉ«øn%ŒNCM¿ÓÚŒy%¶Ùv+Õ}Ÿ n'	»VÎİ²;³.Ãhf(bf—íokœ­³Ö9fêèĞ@`@NØvÔÜğlv*·‰À™y6k×u^¶Òã°²gÙXlÛ&˜éoù/b¦l§jÍé4:ø6o£F2fÔEîfqEƒ,'r¦¯ãåÛà-0ŒC,0=·İAy„mÒ]©ü1ß¬6cÏ»«Ÿú[Ş65ÉÜoŞ\¸ê—ğÔÚïöêK;x+ªoá¶Şô`úÛ`2µØF¸ï™—Q5Š9×ı[ºZÈ.â·ï×òıëÃöViCùXqŞ=Íc?[ÆÇ±h,ì ¦[s¸6­wÜtÜ”Oä½–gİud6—ƒë<1(o©ÑŒ7Â¸ÀuOû%[Á\yÁ<&Kbç¢MûúËÅÄìœÙ¸Ø5Ø	²Ğ\2§-c{|›A}`ßÛ‡NÇãëš—ÑôJm™Î½<Ş–{d³Ä=—3€‡aušnóXÜş§­5{üú7³+·ã—Ë®ç”+zGË„Ú7½İ”ËµU+§d½ô¦Û¬ûFùmeŒºci™uW2óÇàµ¯Zã“Ù—O-˜V·³[6|tñemãV6AfŠºÛ÷¦ÊİNğ#c‹ñb¬ìSÙîÍ'n _jÈK¨ƒÙ¢{8PÃîõeÀJ®yìÎÎ¶Í1®¿Ö·Í”İ´èUÆ1´…	6ÅiÓ’º±).Ì­|Œè9Ï˜1ÛˆOs¥eà'ØÀ–Öìœ± -^vs¦è¤‡%÷èá+;±qi}]'Ûı¬vV²KRÇ’^ç:,JD‰Ç İ›	±ùÄŞÀnÌ-té]E}vK½]ÓBLK 0    blsc      @      @      M(ØÆ· 4)4Leh"ªn  <‘(M  (M  <     $  (µ/ı`(LÕ¸ Ê„Ì°ULm $X«Yæ—A«¢zmüZĞ•0Q &;7¨ %¨ÆÎbòg'b+0ŞÃ¶D¬cÒ±•+à‡¯–lw ‡rK¶²çş/è(ÙæÒ‚£«f[‘¸—qÀÁ—pğı{‡æ³+ø/Õ÷½ Ùöª£ù›Eı;îŒ´‡6K•ºÏi8ğ÷üë	75øo8|õ¤j¸4’µÀVsMèzÒ6í?‰êº×t!w S›Üş%°ĞÌ_–6ğ—¤ã/Í¿ÊĞÒµò_·€Æ†À/›dó"Lª¸qÙvÿÒHå’|oè_¦~¹MÖBO*ùR’¬)“Æ-ù–åøQ£?z’9şÈ	î_şå[öËÖ©5~´ÿr-:(IñËÓõ—Gî~ı’ü¨‘_ª¥FôšÉ?:ÿp”şf¿\K~¹¿t¿,?Ú©£ö£ôO¬È]ªÉ.j¿4¼k#	=ÒÖ"Á;´pG‘uy\S›\j©üëB‘&Ú¹§˜cî89;óÈºÙÈç{?±’EÀ2·´ˆæØ Lğì¯ØõßîÉ¨tÕõò?ôò4†Á¹zË¿…MW@M=Ì2şÛ¥‰­ÿEœ€Sÿ0í;gÍĞKHÀ+à“Ş6ìØq!TBĞÃIo<›Ñ_¶†üw:¨v¬YkPbao]•X¦’cçÎuê º[#i	ka#@Úâ3í=öäkh¼nÍlÂĞkÅVö¾i°cÈœ@)Ê“ÒSìnÁ™!¶ÎJi5ÆŞÛvÈ°ËXr)hT´eÀ®2g5h4.$tÇ‚ùDd[¡£ÛÉdC¹±ÙvCù"ğZ²èĞ›È-šVNˆÍ^lmÑ‚]˜<L3;Èna¤»îGÀì¼g1@ÿ‡½Ÿ€@ÀH¹¼™ˆ¶cÇ=P¬<dğ†‘”£ÑMfv„Ag`t%c®²JDÑÑƒSEï¯wØ¨ü±#ë1ŞÁõPn¬.æ¢ë&mÀ8]3o¡#Yê~Ù*Jhhêò«áUYĞÜ1¦î^Z¶— ±µò¯‰ğÿï¹Èt,9±İ.§“µ€DV·:í¶gµ™4…Àğ9–
+,ıp8¿¨äXl"AÏç²IÅgak%lĞAÿÃƒŸ½N—Í;JøYŸ%øÿ¡‡§{’dI!ÃßlÏ;†uº˜…ÈœQÒ3M>Ü4`†JÇ”B6¦†4.ÎûqõöŒºò½Me”*­Tâ5Z ‡•Q)(ıÈÅVHlb]5"¤µ9)’QH•†­á$9FşY´”´ğ¸eÓØghyÓZ¡–±2åÖ"æ	4Ç•*xê$ÖJ)™ñÛ,pGÈL6²5º]]>Òlq²Ãˆ¿Çò¿wIÀ,MÛŒ>*“g3›t_İ‡e¥ÎbPÁŒ¶ ¨%ìhÅş{ÜÄ‘£"AkÓîàï&õâ½ùh2%Î%¢,/•>ŞaÔ«‰t†¿j\kÕ ½Kªàƒ¾ŞÖñ­®jk»¦IÇâ‘‡½ÜWj!VÔØ1Ğ„ŸÔ×Y-â¨hÓº‹Æ]‚¥öv¸ ©Ä!rIµÖ¤ÎËöšO$3èùs«`…Â˜¯CL©:Ó™Â>	ÃıC² eàBÒt`ûPà,™À¼Á/é‰£¨„‹=’ã €P0Ìó< Aü©Ó1EÙ8o}ò¥ÜqiÊ½äjqF¢
+zTâ`+Şá_S;V(4>×—œ|Œô/ù]Ï ùÓ\~)ˆ+Ì.I¾ƒ±À·&ııæ…Ôş£.ÈŠçĞ±è‡• ÜÓp/=e;}—œø«÷oØao/í®’u{ôJíIØö¯Zögø.ë¦‚2^<²ı¤ápÇ
+ûŞ¬âí¹çø‡Rÿó8ÇEAjÑÇŸT>ŸåÅ?Õ®@W›Aÿ¿;/Àİâ^_VøøĞ…'¯¼8ÎÕ¼Õ÷IÈ§ğn–÷Ğ{cïÖijç‡ÎUªG÷©Ã÷µñ#æÁÒ¯ü’c7j÷ŞéÁÆK¤ş¼]¯œ\¿Ãş£^ì?h	GÛ×m%j™• ã¥W(9&ù%Ş;?àW¸´Ÿ©ş14×ªÜ;\C#8°ç®şcÿˆí¨®*ø­?î_Ú‡[…x.arıÌõ-Ó{^6şq­5/ÏÍÓàš€¨áàÏeš_ûÂ§Õë¿€úŒì}ƒñ½?¯nÒËşf=ùºæ<x)ºY«×ŞÁ ®|ÿ²šXVš}›øyïx£ğ˜v÷¥GàlDø+VÒİªø]û]Œq/ú›õêş%Ù&"øºı.õ×ñh7õâ§Òé÷Ê¨éËÔËy…¹?[pİxÅÙƒx0üÊ½Ë’Ÿ`Ï{èA¬F_r`¸Mwû¼	ı?“tñ¾Û‡ª»û^ÌÏ<m¾¦….êA‡—g›âá¿ÖáoÏOPz÷™±´×oÎ&ÜØšs¿WzÆ/øı§Î}±WıIˆú6œos.ÿÒ+õ/>Ñ	‡.ÃøÄ…dÈÃœ«ûW‚ÇAÙØÕ£ekJ»czÍx
+KK¦8¦‰øC `‹¡¿cùâswÑ;Ğ6u¶A8ï$ÙüÇUğØ¯vıúX¸íÿs1äç[,™Ü/GV»È¿mé2¾g¸Ï³®†ŸxdN½/uOÚ%è×€ı-äyÑ¥=*Å]ÔwØ{O½“õ2OÜ_oucĞ7¼qQ.bi¸¦ÑCo¯\ÿ€ùºö~Ï`jãü¬eã•îóBÍÓ÷B—¯é—Á¾•ó)æ!k“cwÏùÌÛ5¯p½ìxuQş%êŸ;ÔÄîKôÚ&—ëydŒoèÙÏÍî¦ä8'£yïhKş:ó€,é+zNõáÍ_Ö—:aöël“Cd~µ®Ì†Ã´Ü¹nB¼¸5Œr_^--}3ëh|Ñş â/xXØ€w„pºçFpGÃ“Wıß[.¯m».,™üTÖSû0Ì%Ë¶÷İ/›Ÿâ§pÍ£ÿK¨-ø¬şãG”™	8Y£Ÿ6øÊ­Aÿõ^DZâ}é›$Çg“húıDœl…ìŒ´’[5Wõ¾â\³yşaPÆÓ!9•›À|—¶5ŞÑ…/sßaºM0?"{­»1jé›õTñùm-û?Jor¾Í”ÄÙ›ag[ëç¶³äfà®>ÂÚıç—dVyZ·z&õK
+øÏûy°ãÅ’t×ñÅ„–üúeë¡¥å> ü;•ÌKü#ùz\‹l#åWı¡™+†[…Iæ_Îò¦aÿ|"ù§·µçDø÷´a2éü¾b,Á>×û¨G(Ó6çrÄ®_<7m&.ÒtÁf®t"§YXáD€¿¬[|q7·‡oˆs§çb_7í³MÏ/~>Ln§3ã«‘Œ@è¯µ¿L>¥zÆ×&K­¹İÛÃz‚ª§I½ß|ˆ6Ü¬G}z¾_Ñ3Õ‡;ÅóÇŠ¹´ï`äS= •³EûaŒ—îÓéƒ 9£>Ş¿èIû}òsVŸ5ø´_³áıAVı,·lßÏà`~÷èÛóé°¿CÂê=ÑÛ«ÒwåA¨İNşvÜ,©¿÷4²t
+ø÷‚ğ5›‡~?sÿô¦gVÿ×P|2ë—Ë|Ş;;±Y½c÷¯óEÚ¡ee<*
+îÍs÷û¦Ş~×ØMø´×+Îíve%±a6Sgz8æ‹4Zø<²Ç Ê¹8Hş©¾md‹5E¾|üV,°d%¢ƒ{ÓgùyÃ{O”¡øw9ï ºâQx}zÄëÌŸó,¼_ÑÑÿ»c,wÄhšôú[å»ò’;ÿOâ’T#!|ğÉò:¼ÿ× €Í_ìKö²àqz †à¶(z¨5š¬-¾}æEÒp²†¿J5Mw«]óOè]Šß¾Ã_¬÷â &bàúŸ0†ÓŸïº½ Ş¼ªëï3w®ÅšË¼•¯;ÁÛ„!³ß½´†R“·HØ¶0Ì?E(¾ìõÕYG¿`ÿRgàTG§i[ÿq%Œ@Vz~8îøâşç™ágFo/{Â	x¿­‡Ruãx€F›°Ü©°À,`¿}ıñ_ü#]ÄÚsE“w»ÂsôÀjúãÁG~`ı+œß÷›µ:8¦¿?°6=Õ©øiYçy‘âsh±‰ó­9±!×óÊÛæütëK|‰©ïÍN%|¥~Y™W>«sÇ> ·¬xª¸üüõñı)C[ŞØÓ`:›æË€sÖ~â_ÈÆö±ßÈfÒöd:nàDÇ*?ŒşyHóäÿè‹œ­õ)¼²xî½p=Ï¾/ñ£cnO–À7Ş/%İ0¸Ìe
+İ&~@½“Ó4mŠ[úi½‹ùx·€É-ïT¸ì_Ä*p]´^à÷ódúl
+å	ñóåñãµš‡6üÿ:Õy¶ÓòÏ†ÀxÑÃ¬›²œ8|IÀÔlÏÆW üoYÈ÷Ğºÿ><ï ÅÊ:ŸÚ™¤50,Ùw’lNmÏË<‚™EÛn>BõúĞùrUt£â›% Fç7°Ú9ö—Š†§Û¢ÿ§”8xŞØÛì¸N!OûoÁ7&®º•8TşŠî„·_ş‰CşÆÁr.ôšâÜ’¯KÏÈòş“¶ËÁŸ3âàÛí®ü÷ö5Üh [Zöj4_ööƒQæ–ê?C†ø¤¯8‡ëEƒ…øó¼Ÿ›öU¾¹Ñî9¯À—@o)xJ¸5"NÔ[±]úÿİ†<U“–¥ãuA×Ç†¢ïP3bgt¦˜·×o«ÿ,“ÅC·÷Ó§Êí#_Âc}~õÍòÊååÔÁÔğ“µØá?ÿ[<„ÿ­ä¸ŞV¿(,¢ˆ¯üâ»wW}Ó–/7¢ñĞĞó´ğwkÿÒìTÑËòÜ¾—/¬Ú	ûìé>xiñUö‘ÊBO9äÔæÛ'öÀëößìÑÜCõXüvsŸèÙ2/=³Ø¢àĞì8òäÕ¤gíŞ¢ÜÚmÆœ‰=6Cà»¦+6‡g‘-û]ó7>ãáO>ÿåx,»õ4!›:wk…ûJºÛµoFRvb…ôp£İŒ‘Â‹†­ÔL¢™Ûï‡r]„™8N£s×çaù'W×ü¯;I73ïAÁy7­Şaÿ}Ş¼Yä}‚¸^ÎzsÜxZ‚¦Ïó²Ç‘î¥.´ßÂ|å:áMn¸Êüc+1&ÕÇßw˜àó?7yN7Ìqo~ÛˆıàÏo;gHğ”Gó#Fyâ“•ø˜Î{åN;,îqqä§{Í³%n,³PçwNÏç˜ìÇ[L07ı[œ“ƒƒÓæ„*—\óºbMér»¨xêa¤àóŸçëxlı¹7v^³İnoVL×_Å·ó§™¾­ü¾ïdÉCö_» 9^vˆ†¾*ß˜”)|©.]]ìïÕÉòö…v¯‹gçz¶Âá?¼è’ëzO{—jnì»çÙx®‘°ìòç÷á\Véªÿ ıs›½Işå|)9~O˜ßºÿPÊBµVvóTïBMÎ•âfz½¯Z„N›“ÁrR' >wS^K²,÷=„¿¾ïğm?xÁ8¯Éünî–¯¿)mÚ!áş÷ÕécÛmàÆv÷È:)~‘ø÷XÉ>ş°ñ­ùÚÿÖß„ÓùQßp¾—Ü‘ĞE‘yåÆÖ¥æ‰x,X~ì¶}€1/®¦œ’k¹JÙ×^§´="¯rjß-±qxªt#8›•–`
+VÕ>.w‰ß#Yøâ#yİüÍ—cF­Øx¦Éœ8Eğ—0¡éæ²Üx{Ñ3ºa3@:›¶	¸d?¿Şf`a´aKóÚíJŞ_Z˜¡ç”gøìÈUÛ&?SuÍ>+:¦Yçuª,g<sÚIûU\ğ‹êS‡?³|…æ÷¥» ùLë×ÓSËgª6ÎnnpÖ=o3øÀ<5óF‚™ºlß>n5·Ù{Ÿş²Ëşöµñ>3D|¼Ê½Ñ©b^xL±8\²?àÑã?ã^À„¿©säø—áµôN±d)
+¿ï°¾;ğ¥²¥0ÕgZ~W÷`,ÜÎ%šİÎ¿›µÎ¸?¼3èXvà¦Øu¹xÄFÇŠïAù•bÕX=–“ÀÅ-ÿçcà“§üÜ¸½­t0q¹Ô«ÇÂí' 9Ï0nÿUŞ±o·Ğï]·™+{Şşw¹«Ï™S9ŸÁşß~/Î¸øÉÊŒÉ¸îc¡rdòí–tíˆÃí`¼ê<Ó;.¿%ÃTéx«ãœ}›À=óììC’Ÿ—÷¾ß‘xRtŠnQüÀßLìôƒÚîO¸¶Tèˆonÿg˜­ÙGı~…ã¹}Á¯‰{\ôÄºş*ñméfıø“ç¯ÿqçuoØP&®ê·|ŸÿÌF©ıòÏ7Íc|ñ×İkı>gº½bö¥«ô?‡EÒİ~p]tY›OıÿÙ>*ï…N¤¶º1VX“H°Å¹Cz‘½Ùl•pÔĞL°}z©3¼BïÛj¡vËB ü™ÊGhÂâæ½ä›Åéš‡0Ş¬AÛ¼²‹®Ñõâ+ìL¼—b÷¯¦]Gó}d®l¿†<Âlß‚8İÍHª‘v[“ktVüxˆ?€á¹ìµúéÍe};÷„¦ÿò’ƒŒü0í\»”ÕüÕ°ñaæø7^€n3ó¾ë¹; ú¼–‹‚ws_œÂÍY_ºÑ‰Îùe4Jo
+¦q~í×£87So²r¡5T·\!¢I·â[¾ÖÿÂZLa´¼Ù?
+_ sç™vÈ/í7<c^WOG¾«>ucÌÿ˜ÛL.®²:ŸCs¬O‹F™nïwfW×Î}Å¾PòLè>oş<Ê±Ñ’ºæhèö¹„/¨'üƒaŞÈ¦÷#zRYMı‘ò[Ïy°Ï}-k‡SÔŠÏ?¹Ê±ôä“õ¿ïãŸvÊ=¸Wú`§¤é6†sOÉ{&èíhğ«c!/Ä«t>÷#ÀÉŞŠ†Ïj:äøt^}ïÔåìƒp»}’†~Gò©Şy»]íQ»ê¥‰˜—Ã: Nsğ¥~~dçù£_İ>üş²“èøÆøòoÀı]…ô¦ì+E£‡¬»ÃS±Ÿ;ğ4R–òŞB'0æEw²â'F!ı¨›ÂH¿Œv.»Côµ‘Ozó®¾‡ùì/Îm>Kİ˜crrİşÍuÛ_È¾¸=_Ì÷ÃñW¬Şïçß³ÎKö#-®÷ >`ÀyÕ¯P¿:"½ê-HõŞƒ÷İÒ'\­ØE×O&{¤e‡oj^0ş²kçÃ÷;øïÿíqæ^qx€ŞÛÈSóqçøvYüG‰|–§õ8n¸l#é°ÌùDÏZŞ[u0b­*†~†¶i°ba1äı ìÇh§³èëóaa™ŸÓM~ÀænëÍëÿ+¶-­Ô:cm1½ĞŸ0dßjnì3°¢º€é»¯ç)Ÿä˜ó!xÂ#’@ÙMú¹·`9Ñ®ÚèY÷±‡céiıeú«óKŸÌ»DE2nµa¸+SÂ.ıØô‹‚;rì¡ğùNê)5X_J°õË}fÍ³Uaçw¾—NÔ?ß7/Â¦½?vÌWl‹›ƒùÉÑuù#ø›×ÑÚ ;Hsé}“wÙş^‹±ìµÛv×‹;Î´Ú|u];âg™z¦±èã*õ¶sÇ×yñ”ÎMşoªİ'îÑ™‘ubHäæ’ş_ù‘ùk9´ÇÈê>x%àÎğ	å Ñ“ü*ïZÚÄÿsFº¹¾ÿ3øwFåï,ıÓBLK 0    blsc      O      O      &”7b¬^îtä†“¢ıûi  K‘”&  ”&  K     3  (µ/ı`”%M‘ º‘( |Í³1P[6aL
+?}˜‚ª²•*ÔYBÕSo»R¥’–Ò~Æ´-x;Ğ´6ÓtöR˜BLi7Ii%Gi-Kg)E¤µ‹¦·Š¥·†áÉdjK:Z Qx]QÛC©”pKKJX+úˆF¤m[GeaE	eGa¯\—k(!ëÔĞ•t“¨¨ìåç=¹”'	6~> ¶ŞOƒáíÇ“[‹Å4„Áf©"ĞÙUOÚÕOZÕÍÛÔOYUM[T‚±§´©eM$€œƒ’INC/ABn+ÀBÔÍXT€İ‚—İSNYÔJÂ(@Ã¡œ… ›ƒNp“ğ“«k¹Yèİ4DÜl<„\Ï¹ÎBCÏBÛİ—«å`êåğt²Ğ„:98¡Ô4ŒÈUÄ,”X¸Ğ0q( Ù]€‡OŞjvW¨ĞÈB³ò0€“’«9Œ„Äì.jr1•In¡$rÙÇÂØëâqÔ‘@‘r"Y8ĞñĞ{¤$„¤,$l,„,ä>¼Ebá©ô[XPºH8ÊHšH‘üŞ^('k.r¿´¿„…İZîwÖñ+Kèå¾x!¢!—q°k,‰·5ë¡¡j·´;©·’L´í¼¶²‡…ƒİAÛ€‡¶•ˆ²™‡³Yîmm—;xy{8HkhHé¥eL Ÿ”ÁŞû jímÁÛ‹~Kjk+²¼-¼Í|•õÎÎ2ÂÆ
+äÆbÎ¾6ÆÂ6zk½·ˆµ³·³Šµ±™İXÈÚWÈÛWË_5	c/¹°	¿°²kc‰H…â#3r‘ÓxqLè˜Hr%)”ˆ–‘Š“ÊDÂ·ˆH ºZM»ŞèóyhLô¾Ü®’±ÒQñÖë½àu½îp¨j í®R»‡&SˆÒÖÑa.2fPn.oia¼İB4Ü£rõ6Ó.ak‹@ÖĞˆè$¾.YGtm/^W®@8“ÍÂj1ØÂXÛ,kˆjÛ=ğ5; ¤Û(¶Ö>:m¯Yg0Œİl°WCØ—+!i,aªàk!gkå:øU©X¬Ö!ÖÊj-<e%D™®¢^ÚzKğq¢
+^¢Ú!˜OQL¥¶ªTSS'ÓCÏQîã±t0â®–
+–J4†B†+×“i¡ªÉÔ°ÀttĞfè­†4šãÖ‚v*XÏÄ‚!ĞAQèç €ézæÎüÆz~[rˆ©šŞ’¨ÀCˆÂèéìÒ
+ô¾^z_¯˜€‰¬R€ˆ Œå ç¡w³ÙDÜDÂZª“‰%âhÔ²Kê\2˜™Şáê„Òk*4,‰RvCŠÆ€ŞÃLo'ƒ}ìª
+FvW‡«ßn©c!I´‰øÉh0$ĞtDt|®ñ‘ûp4œU Ê&vS*S†i"7u"e4\PJ8Eã!,—+zÈí(Š„‹â{H8P¡h¸©İj´WZí ëÀ¶Ğ¥b½å–R¥QCÍ°;i*‰€´³ˆ…µ1-@f¬-C‘K˜¡t¥m$œm”ÍÖN*z	o²²œ¶Z[NÄÂÛBl,6K«	Kë9{Ë“ÕÖh¶[T©¬-¨ëlè¬mcj-ÆpµrµŞÊZ›ªj{Ú:«Í\¥-}¢ÊšºÖn¤í<•M[§•–ŸŠšOTÊˆ`(â	êõŠ!PDbk¨¢*§"ëgô»
+
+¹ºü|¬ôl0Â@G¤Çóñ€>¿µ­PM ‡óór*š‰Šk,¿ €™ •‹–™™LFmæb•JÏæÒ’1 Å²“©Xy¸HÔl)“ßÌåj­T!H$#	ÄÉdJ&™Œ_HåòóÅJÕ«P,F¢ĞÇÄ—xxTP2>F&¿FN±Bi¼Š±`$†:¿‹ÑÓÙøåd\„l~œè=n.~ˆ„cé¸x°û1
+á-¾"QJ¸
+-ü&’Œ·–…–¡¶â)Brµ’ÇJ‡ $Èl/%Q?€ŒŒÃdÓ–Q˜xl´Ø+LF‹U*ß…%,ÅñÃq.¿Ü÷XñH¾\oqó5èx àhşˆ[I$'_´„ä¤ë$ãábd«¤cÁÄ¯·è^nÂNb ¦>!O9†Å.µ;p>‹W¬ÚÈ„·†7Õ×CÔ×DÓ¤)c¥iæ*ˆµB‚Q	M®†³­ÖªáĞee•\»Ÿ­ÜÍSÈO(j!HÔ…J0i2K%C]¬+%Gijhd,äN­rMT¹&€¤ƒG5K$T)Ç¥ÅšR]O¹¯TÔ®I2à•B_KU©‚¥Ó.¡H‘¶CPáít0=5›ŸŞO''‡éñ€&n	zi1WÍESÀ@&’ó¹QŒøĞ ø•D*&.r6˜Š®˜_–jf¢e &"À@¯d2@ó»( ™˜6#‘ô¶PËà„Òƒ¹\¯ë·˜h2…D¼ ÍÇDLÉÅEÌDYF¯,ÖKxİ—d"Uü’cm'“Å÷ÅZ¥R¨Ó	ôñ¤­œŒµ`"„›F³Íf2™L&“É¶>(a.×ëëu¹
+›­P²D¤bñµZ½^*ÔI– “ë¶~ß·ã·°«çhË‚Åfµß-«ãlldñ´ºb…T¡ºB*+O%-”nÁ9ªLD¾*SéEñğv„F’ìÔk´ÙdS®§TFVµ¥Jµ´`0M1¤©Ô!y|±P§SQAK‚¦‘I'=I%É¢¥heÅò8D)¤mæj­:;A%OItCP‰œ$Øhä‚<gÒu³Ñl$•87šVr~>39	JE˜‚“£œŠJ!ÎHådbØ	ùít:HVÎHS¤¥á¹ÉØuŠÍGîÀÀ@@JS€ A6`Ád4M-—J@‡ÃÑØè€”Á U¬FĞIÆ'à’Áx@®Á.©SAäbgdƒq“)Ù4dR‘†ãà€p¤ãÍÒ1k‘FE¿¦@È#±üŒG„‘Áqa—X±ô2:ÇšM{íBªNˆƒÑp\"¹\€Ñ0x@t'’¶ˆ“µÙL&;h9Ë}XÊF’¡¨a­¶riXğn·+i6ZmA6è‚¥d±¯*!„QµJ]8¾Ã"i-VÉ+Ô+¡r @$(J®Z‹öñÖ¡9ûèH8;Qc+Ÿ¯\ƒÁ‘6r(pµğËÙb3ÄÕW„¢)¬â¨«äˆtv‘ry:%”$ºR<ÕK&s­\®ÊR–‹”ÛÁ\’D=D§ÓdJ80)bZV’&~²F5X#‰ÆRé„*`ıºªTßÔÕÃj+5räù<¡ZCI$«¤éã9J‰B!;GŞÎ‚“G¥•—#’H4šˆ`™P¥RAÅVË•T*õ¦V 	„6¨C  ²À
+P@AF
+’¤C"ÁˆP2¿Ü~€@şêÓÏYõ`ş>:ëã«äŞê–Ÿøo²ÂLVŸVş Î{-Œ¢ô@”tÒ	»Ëİ^K&9³&?Ô°¨lö!ÅÎÒ`MªÿoîŞÇÃ‰™õ~^²¡§B·Çö·M³EK– 4!¦?°(a4¾“nÉÍP]ı›ß
+†ûûK˜ÅV‹Æjo¶E{.òB—|Ññ†z„cî‰crôƒ¿j—3Á4ô{jÚ\C3ÿ8K›½*ú;<^ÑºğG±+¯³#)Nuº½òwöæ<X!¨ƒŸ¾¢:'“°g-Ä»ò,b%ßR:”«ùŸ\Ü¢ïà4¶QK;a'qÁ"9[}ZóÉ/É‰p±TyÇ*íÉk“ŠW™o$½¿;–"éÅ~Ç„˜àcU@¬ôNrIgß¼§”’í)¯ñL‡)ˆJ€ÕÒ¡‡oqÛú$ ³0fZwDÚ ºÀ'ôUÓÛ„÷qüÔ×¥9ÓzÏçÚ(pËC0èªÛD!µMdS%©ô6~”<ˆËEqÑ"õ¯cåIëìºî—25WæDúÎïğ¥ªŞ}E+Çd=òrğiGÈè}ßc*ˆ‚Œî O1ldoÿşs«á®²¾¬K«6e”yæÊÕ¶½½M¦ê›Šö¶æ©•&pdÕT§•/oPñÜóDŞ˜Uúö›mGa0{$}B"$„•%ŸÛŞ8…»ªk€Ëú®£\]ıSŸuÍóõ'P<öÁÓĞğ-R§TÌšò‰­Ypı6ä»1ìEü±óåÌë«&§4ÖªŠEÖÇƒ¾vä“êvõ·Ã-ÛdÉÄtly¼ßşüÆ¬Öÿi#—¿ˆqCÔrêV],QV÷WDÜ,ˆ·fl´šûŒÜ‘ïBûİµÎéN]MÿÃlƒ>‚*?æìİ}ÁrûÚÏ~SiŠ7ÃÈÆyÄ²VÛñÙkş–ßæªJ2¯³áiêåHÁÿ²å/dôŠj³ú¿Z3r.æQŒÆ¥ğ|sàògèRÁ4WÔ7¸	åñoîyÓe»ªÈÓßÂjOc9ÿwt	ª¦hïÁ7@ßëı%åÿÄÛB>‰÷;/Ë\ë-h†­ŠÄ)ÖÍ›XóÀš*p"–ÏÀz„¸uJRû‰¢Î•y×Jıw;wUrv­„'f6¡?´¿<â¸ûümîë=:ojşxÈ ƒ¼V)“Õu,©úÛ´ğÊ„_”öİğoœvÑÑÓ¬e·¹
+8¶~}eª'NØw*‹%°X—:¹å¶ö98ÔÑmxÍ[gt3¯KoÓYP¬^O¹q¦½^/¼kôÁLçi¢-Üä	{íeûÁS4¨§Hj¨Üö;â7ç×¥&æÓ‚(é¡gÕğÛ-Ö®1°t¾ÖS­Ö[¾“o5Øb‰Ê˜L	Ë¨^-:‘Pbİ²äê©vqUï_È(JV¸§‹#%ËcbÌµ&Bƒr7BCŠ&GÍ2òK	wÕQ@ÜáÚGÁp³R‡Å/­ÕßÌ3LºÛàñ\¯°±)ÏçÑZñàÕÍV
+˜‹$€»ê{ôÊ½JFÿéx!´"ç“Ü``ê%ynP&¶YşL»µÑÇŠßÓ¿¹ï•Ga|™n2B…b'¥²}“Ûï3¿Ã²[y°]©¨¢d®TYâw+÷ék*¯—ÿ¤^möZ\w¼ĞÜY+›pá’bÌTj„9µâ¸ŞµsÑÂ+4&,•X{YÛ0L½Tı~-éÎš<"Œ«£ô6aº¿yŞıoÂMæ‘ÙQMª”[õN»/ÓÑjÁİß†ÔqVŞ1¼:»4µg%ê[]ÑY¨»‡^¹•Aæ0˜âã*|_`~ Ø”àÛb½óÍñ…õx­<ŠI‹¾<kŸE.{;îO¾±#Kiô•DZšô¿©"õ;D6[(ÿÒ)¯¬š+¨’«ÛÎa« —P<uz.	6âºHp·­aWüÄºVÆbê3í<vÌ`.NÍa9:æçÌuXôn0õºï‚)®8ñ«­ÏˆL¿yz81/>RÈ'Íşû?õĞÆşìËñzôj¼MµË?mOlíC^|7¿¨eö†3»;T©İ-÷û
+ë_ 1¥ïDé³!.y£6š…Qòºpˆ±‹W?ÀµÓªÃRÿôVÂEæ†Ú 13x?ƒs—0Ö0«û)OçšXÁ÷­AÏæ.ë[aÜû¯jn1(%¶k¼]˜ĞŸ5†ílÉqMS6¶ò‰„¹
+`Dù$,ÌÍAfDxg¥$Lª›¶…Òí¹Égì¶ï£“j¿ö¨hÓ×•0ğÖÿ´ó•Å®Õ­#k>vú%9‰ÒêTç•+üÍ³âf(Á°ÜßÂócJ`Z!8ÆX^áçz5>Rƒê|Õ)ÎÙ`&´h[;mª?`´G‡t"zìf«Ó| Äá{ÃÕ§k¶¼9‡¦¸
+½Ù\“¼Œ9‡ë^ƒğ#ÖÊH´ë%ŞQ‘‡nD;êTà»íw×]õ3ÃwF™s%×£™”ú.¡iÅRü/Û‘eĞió™Ãşğ hN‰–jKğ“´Ğ¶HwYÄR$[Q×&ºl`İ<¦JÇíe#·Ëç«9è½8%šu¿c¥´Ê–e=ÔJéy€´á¿ğ.¯®ÓBLK 0    blsc       ™       ™      n£02öó<Ä*¥ì|mºĞğ   •‘n  n  •      }   (µ/ı`n 4             * “Â´?Cíl4b94C7Ã=(„Òç&ñ.CãM4~ƒ‰1(2˜ûb5]û›¡%ÛId°œ°áš…òbO»ªâ'…cÔÄÓBLK 0    blsc      ß      ß      ¸ÚJ«NêD!İ^HÂ~š  Û‘¸  ¸  Û     Ã  (µ/ı`¸Í- –P À%ÿ¦ßõÿ»!MÊx¨^
+   C©¤š&:œŸÌ°ó«´+©gøRÒgØ:õ›ú(†–³	6Ás¢bS $*QiğÔOÒ
+ R]áƒ]§=ËÀıodÓ|„üFvœ¦iüŸÀ 6Óoe·ù½¨•ÛLÏUæ)kö«&‘®[ƒN¨rfÒ2
+8ˆ#q øÖ@q°’P¤E©,›O‘È/à'w?”x"•slÍ5iV'Ÿ…+DSCöFëû2ğCã˜õùËx­­’ßİ;¸EÇ+‘İHÓøóåë–¼ÅÜQóq»æª:dæ†>7~ŒEáoX^Ôßë¶—^•ğÓ0-TH=Û?š–_ŸL¼8Ê‚˜†'ªÛxonœ’kF(Føúï@¼o®où¡zéğwpÿOâÏ0l<æ·õÓ7‰“ñ^õ¤d¾t±?÷{Öñ(¦?;EÏ|°õ+ ÎïÙçòÉCÛ%zØÆ¦Ã88AçLxZÒn•+8ÇË43ê¯Í5øÛ˜7\xKéÆá«ü”Î—ÜÛ]ÛÙ+_×ñuáÿã˜î¦só¥Lç=WÓZõP“°²­]Şz!ötWbãI¿æÛ7¼õFÿl>>q/„ç5WûŞâá~;Êœ4†êtÏ£	6DÿÜ+{×öå8N;ÍNİôÆÊ¯Ñ¸æŞt“Åõ:ÃÜè_n,Ëôù|Ÿ(b’Û©Fà¨6„•_À~ô_İ¢şy ¡ú4È†d–ü™Ÿ–üÀÂ¯X>fôïuÒ.mWúÜİ–üA£òÇÎ\Á§r ÿ)Âú¨e>ã‡ 1»àù|ö»ÓŸPw»˜Ÿªı÷aÄŸ­mŞ™?¦'uô+1:Ô¾æô^Byß:‘ã3¯×}EÑç;¼|Æô=LÆİhî»|Ä¾¿0z†9§³€8ÅŸü=c›at{iÓy{îb+/nº*½i~©ŸşŞ`^¬Ï½îæâğÏVÅı¹79#s×0şs:Ás´Ízh×ñ`¾YÄ¿’»öpÖªÈ«ššagÏto_¥u½¸ò_vä˜-íÅôºº&/|ù 5Ò'ø¬À”ÏV3H—Á]Ğbßg´@N·2ô–›¸Î ¯ÈE^V‚QwÏÖkø³¶Y»ùò–9Çù®øñ†a”&t½Z
+#OáC½Üñú¤ìk»Ã2°ø3¾Óœõ>A7ßwëê²İä	}ŞÂo;‹KmíÿÓ®µñí¼‰+hğ9~|3sêWÕ\óÔ;M·Š‹S×Ç:î™Í`çCX¦Ø*ÿ‡nWhªÒŠş"æ|6ã›á5–OØÜ{ëU‡Ø5À§§³BeĞ¿¤ó’}àf^t·kF?Ä§tCÆúûÍG9›‡)~—LëÑçLªê:j0¿ÿ€¶pÎl_s¨ÍP¾÷YCÅGÉ>eáß»	Û%ƒênrõ³pÚŸ€ù+ËZyF?“	¸·]ü±«Øuı•Ñ«|ë	7ìín-,lgÎ¶Ëo²­oAvôìÉ×æÙbœ×}e3ÎgV<Ü½‚¿Gev5œôl’ç=İ¾s!œéNÉ'ƒŞÍë*ó¬ìwïƒ|¥ÿ)^áæ'¼ÄÚUŠ£oZƒ_sÎŸ¾àöûj¾ğ§\êc¶³ÈÚ1ıBâ-~Ó©3êNà½[Ò©ãª=WÛ•g½cø!æåUm®~q1-ÎÿãÃ¤4A"ğâ[Ü+.ú'%å|q°+z°3Ñ£2H|Ñ^9ã?Ò{¯{ÿ5ıN2{^šùàüÅg£¹Y›`åUe\~Î3ò“ör8ì¾×g›ï+è±ÙÂï¢îtVÿğHø“®Y´vşÙÌ~ÿjì»¤_%wÎ¸’ëá€‘Æ×÷ªºè[u­#ASDF BLOCK INDEX
+%YAML 1.1
+---
+- 11644
+- 29774
+- 40365
+- 46416
+- 51793
+- 57799
+- 62540
+- 62747
+...

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -11,7 +11,7 @@ import numpy.testing as npt
 import pytest
 import astropy.table
 from astropy.table import Table
-from common import check_close
+from common import assert_close
 
 curdir = Path(__file__).parent
 refdir = curdir / 'ref_data'
@@ -19,7 +19,6 @@ EXAMPLE_SIM = curdir / 'Mini_N64_L32'
 HALOS_OUTPUT_UNCLEAN = refdir / 'test_halos_unclean.asdf'
 PARTICLES_OUTPUT_UNCLEAN = refdir / 'test_subsamples_unclean.asdf'
 HALOS_OUTPUT_CLEAN = refdir / 'test_halos_clean.asdf'
-PARTICLES_OUTPUT_CLEAN = refdir / 'test_subsamples_clean.asdf'
 PARTICLES_OUTPUT_CLEAN = refdir / 'test_subsamples_clean.asdf'
 PACK9_OUTPUT = refdir / 'test_pack9.asdf'
 PACK9_PID_OUTPUT = refdir / 'test_pack9_pid.asdf'
@@ -44,7 +43,7 @@ def test_halos_unclean():
 
     halos = cat.halos
     for col in ref.colnames:
-        check_close(ref[col], halos[col])
+        assert_close(ref[col], halos[col])
 
     assert halos.meta == ref.meta
 
@@ -66,16 +65,16 @@ def test_halos_clean():
 
     halos = cat.halos
     for col in ref.colnames:
-        check_close(ref[col], halos[col])
+        assert_close(ref[col], halos[col])
 
     # all haloindex values should point to this slab
-    assert np.all(
-        (halos['haloindex'] / 1e12).astype(int) == cat.header['FullStepNumber']
+    npt.assert_equal(
+        (halos['haloindex'] / 1e12).astype(int), cat.header['FullStepNumber']
     )
     # ensure that all deleted halos in ref are marked as merged in EXAMPLE_SIM
     assert np.all(halos['is_merged_to'][ref['N'] == 0] != -1)
     # no deleted halos in ref should have merged particles in EXAMPLE_SIM
-    assert np.all(halos['N_merge'][ref['N'] == 0] == 0)
+    npt.assert_equal(halos['N_merge'][ref['N'] == 0], 0)
 
     assert halos.meta == ref.meta
 
@@ -121,7 +120,7 @@ def test_subsamples_unclean():
     for col in ref.colnames:
         for i in range(len(cat.halos)):
             for AB in 'AB':
-                check_close(
+                assert_close(
                     ref[col][
                         ref_halos[f'npstart{AB}'][i] : ref_halos[f'npstart{AB}'][i]
                         + ref_halos[f'npout{AB}'][i]
@@ -153,7 +152,7 @@ def test_subsamples_clean():
 
     ss = cat.subsamples
     for col in ref.colnames:
-        check_close(ref[col], ss[col])
+        assert_close(ref[col], ss[col])
 
     # total number of particles in ref should be equal to the sum total of npout{AB} in EXAMPLE_SIM
     assert len(ref) == np.sum(cat.halos['npoutA']) + np.sum(cat.halos['npoutB'])
@@ -223,7 +222,7 @@ def test_unpack_bits():
     ref = Table.read(UNPACK_BITS_OUTPUT)
 
     for col in ref.colnames:
-        check_close(ref[col], cat.subsamples[col])
+        assert_close(ref[col], cat.subsamples[col])
 
     cat = CompaSOHaloCatalog(
         EXAMPLE_SIM / 'halos' / 'z0.000',
@@ -271,7 +270,7 @@ def test_pack9():
     ref = Table.read(PACK9_OUTPUT)
 
     for k in ref.colnames:
-        assert np.all(p[k] == ref[k])
+        npt.assert_equal(p[k], ref[k])
     assert p.meta == ref.meta
 
     p = read_asdf(fn, dtype=np.float32)
@@ -289,7 +288,7 @@ def test_pack9():
     ref = Table.read(PACK9_PID_OUTPUT)
 
     for k in ref.colnames:
-        assert np.all(p[k] == ref[k])
+        npt.assert_equal(p[k], ref[k])
     assert p.meta == ref.meta
 
     p = read_asdf(pidfn, dtype=np.float32)
@@ -356,13 +355,13 @@ def test_halo_lc():
     ref = Table.read(HALO_LC_CAT)
     halos = cat.halos
     for col in ref.colnames:
-        check_close(ref[col], halos[col])
+        assert_close(ref[col], halos[col])
     assert halos.meta == ref.meta
 
     ref = Table.read(HALO_LC_SUBSAMPLES)
     ss = cat.subsamples
     for col in ref.colnames:
-        check_close(ref[col], ss[col])
+        assert_close(ref[col], ss[col])
 
     assert ss.meta == ref.meta
 

--- a/tests/test_hod.py
+++ b/tests/test_hod.py
@@ -19,7 +19,7 @@ import h5py
 import numba
 import yaml
 from astropy.io import ascii
-from common import check_close
+from common import assert_close
 
 # required for pytest to work (see GH #60)
 numba.config.THREADING_LAYER = 'forksafe'
@@ -93,14 +93,14 @@ def test_hod(tmp_path, reference_mode=False):
         )['halos']
         temphalos = h5py.File(EXAMPLE_SUBSAMPLE_HALOS, 'r')['halos']
         for field in newhalos.dtype.names:
-            check_close(newhalos[field], temphalos[field])
+            assert_close(newhalos[field], temphalos[field])
         newparticles = h5py.File(
             savedir + '/particles_xcom_2_seed600_abacushod_oldfenv_MT_new.h5', 'r'
         )['particles']
         tempparticles = h5py.File(EXAMPLE_SUBSAMPLE_PARTS, 'r')['particles']
         for i in range(len(newparticles)):
             for j in range(len(newparticles[i])):
-                check_close(newparticles[i][j], tempparticles[i][j])
+                assert_close(newparticles[i][j], tempparticles[i][j])
 
         # additional parameter choices
         want_rsd = HOD_params['want_rsd']
@@ -123,7 +123,7 @@ def test_hod(tmp_path, reference_mode=False):
         data = ascii.read(EXAMPLE_LRGS)
         data1 = ascii.read(savedir_gal)
         for ekey in data.keys():
-            check_close(data[ekey], data1[ekey])
+            assert_close(data[ekey], data1[ekey])
 
         savedir_gal = (
             config['sim_params']['output_dir']
@@ -136,7 +136,7 @@ def test_hod(tmp_path, reference_mode=False):
         data = ascii.read(EXAMPLE_ELGS)
         data1 = ascii.read(savedir_gal)
         for ekey in data.keys():
-            check_close(data[ekey], data1[ekey])
+            assert_close(data[ekey], data1[ekey])
 
         # smoke test for zcv
         config['sim_params']['sim_name'] = (

--- a/tests/test_lc_hod.py
+++ b/tests/test_lc_hod.py
@@ -16,7 +16,7 @@ import h5py
 import numba
 import yaml
 from astropy.io import ascii
-from common import check_close
+from common import assert_close
 
 # required for pytest to work (see GH #60)
 numba.config.THREADING_LAYER = 'forksafe'
@@ -96,14 +96,14 @@ def test_hod(tmp_path, reference_mode=False):
         temphalos = h5py.File(EXAMPLE_SUBSAMPLE_HALOS, 'r')['halos']
         for i in range(len(newhalos)):
             for j in range(len(newhalos[i])):
-                check_close(newhalos[i][j], temphalos[i][j])
+                assert_close(newhalos[i][j], temphalos[i][j])
         newparticles = h5py.File(
             savedir + '/particles_xcom_0_seed600_abacushod_oldfenv_MT_new.h5', 'r'
         )['particles']
         tempparticles = h5py.File(EXAMPLE_SUBSAMPLE_PARTS, 'r')['particles']
         for i in range(len(newparticles)):
             for j in range(len(newparticles[i])):
-                check_close(newparticles[i][j], tempparticles[i][j])
+                assert_close(newparticles[i][j], tempparticles[i][j])
 
         # additional parameter choices
         want_rsd = HOD_params['want_rsd']
@@ -129,7 +129,7 @@ def test_hod(tmp_path, reference_mode=False):
         data = ascii.read(EXAMPLE_LRGS)
         data1 = ascii.read(savedir_gal)
         for ekey in data.keys():
-            check_close(data[ekey], data1[ekey])
+            assert_close(data[ekey], data1[ekey])
 
         savedir_gal = (
             config['sim_params']['output_dir']
@@ -142,7 +142,7 @@ def test_hod(tmp_path, reference_mode=False):
         data = ascii.read(EXAMPLE_ELGS)
         data1 = ascii.read(savedir_gal)
         for ekey in data.keys():
-            check_close(data[ekey], data1[ekey])
+            assert_close(data[ekey], data1[ekey])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
In changing how `unpack_rvint` handled shapes in 2597bbd5476617e911dcf517461d5b2fc6824907, we neglected to change how it handled the case where the `posout` array was being provided by the user. That's mostly because it uses the tricky idiom `arr.shape = -1`, which is a way of doing `np.reshape(..., copy=False)` (only available since NumPy 2.1). The fix is just to do `arr.shape = (-1, 3)`.

This PR also adds a test for `read_asdf` on rvint and pid data. Previously it was only being tested on pack9 data, which is why the tests didn't catch this.

Fixes #164.