### PR TITLE
ci: add python 3.13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,10 +80,8 @@ jobs:
 
     - name: Pre-install dependencies
       run: |
-        sudo apt install libgsl-dev
+        sudo apt-get install libgsl-dev
         pip install -vU pip
-        pip install -vU setuptools wheel Cython 'numpy<2'  # for classy
-        pip install -vU --no-build-isolation classy
 
     - name: Install package from source
       if: ${{ env.PUBLISH != 'true' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,7 +66,7 @@ jobs:
         }}
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 2.1.0 (upcoming)
 ----------------
 
-Supported Python versions are 3.9-3.12.
+Supported Python versions are 3.9-3.13.
 
 Enhancements
 ~~~~~~~~~~~~
@@ -14,6 +14,7 @@ Enhancements
 - deprecate ``asdf.open(copy_arrays=True)`` in favor of ``asdf.open(memmap=False)`` [#157]
 - compaso: add passthrough support [#162]
 - compaso: more flexible search for cleaning info [#167]
+- ci: add python 3.13 [#168]
 
 2.0.1 (2024-03-01)
 ------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,7 @@ dependencies = [
     'pyyaml',
     'msgpack>=1',
     'parallel_numpy_rng>=0.1.2',
-    "asdf-astropy>=0.3; python_version>='3.8'",
-    "importlib_resources; python_version<'3.9'",
+    'asdf-astropy>=0.3',
 ]
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "setuptools>=61",
-    "setuptools_scm>=6.2",
+    "setuptools_scm>=8",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -75,8 +75,8 @@ include-package-data = true
 include = ["abacusnbody*"]
 
 [tool.setuptools_scm]
-write_to = "abacusnbody/version.py"
-write_to_template = '__version__ = "{version}"'
+version_file = "abacusnbody/version.py"
+version_file_template = '__version__ = "{version}"'
 
 [tool.ruff.format]
 quote-style = "single"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ abacusutils = "abacusnbody.data.asdf:AbacusExtension"
 all = [
     'zenbu-fftw>=1',
     'classy',
-    'numpy<2',  # for classy
     'Corrfunc>=2',
     'emcee',
     'schwimmbad',


### PR DESCRIPTION
Let's see if Python 3.13 works, now that Numba 0.61 with 3.13 support is out.

Maybe classy has fixed NumPy 2 support, we can check that, too.