### PR TITLE
tsc: return None from `tsc_parallel` when the user passes a pre-allocated ndarray

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,14 @@
 Changelog
 =========
 
-2.1.1 (upcoming)
-----------------
+2.1.1 (2025-07-25)
+------------------
+
+This is a patch release, primarily to publish the memory-usage reduction in the HOD module.
+
+Changes
+~~~~~~~
+- tsc: return None from tsc_parallel when the user passes a pre-allocated ndarray [#180]
 
 Fixes
 ~~~~~

--- a/abacusnbody/analysis/tsc.py
+++ b/abacusnbody/analysis/tsc.py
@@ -59,6 +59,7 @@ def tsc_parallel(
         indicating the shape of the array to allocate. Can be 2D or 3D; ints
         are interpreted as 3D cubic grids. Anisotropic grids are also supported
         (nx != ny != nz).
+        If densgrid is an ndarray, the return value will be None.
 
     box : float
         The domain size. Positions are expected in domain [0,box) (but may be
@@ -102,9 +103,9 @@ def tsc_parallel(
 
     Returns
     -------
-    dens : ndarray
-        The density grid, which may be newly allocated, or the same as the
-        input ``densgrid`` argument if that argument was an ndarray.
+    ndarray or None
+        If ``densgrid`` is an ndarray, returns None. Otherwise, returns the newly
+        allocated density grid.
     """
 
     if nthread < 0:
@@ -117,6 +118,9 @@ def tsc_parallel(
         densgrid = (densgrid, densgrid, densgrid)
     if isinstance(densgrid, tuple):
         densgrid = _zeros_parallel(densgrid)
+        user_supplied_grid = False
+    else:
+        user_supplied_grid = True
     n1d = densgrid.shape[coord]
 
     if not npartition:
@@ -197,6 +201,8 @@ def tsc_parallel(
     if verbose:
         print(f'TSC time: {tsctime:.4g} sec')
 
+    if user_supplied_grid:
+        return None
     return densgrid
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,3 +79,6 @@ version_file_template = '__version__ = "{version}"'
 [tool.ruff.format]
 quote-style = "single"
 docstring-code-format = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/tests/test_tsc.py
+++ b/tests/test_tsc.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import asdf
 import numpy as np
+import numpy.testing as npt
 import pytest
 
 testdir = Path(__file__).parent
@@ -205,3 +206,25 @@ def test_partition(seed, dtype, npartition, nthread):
                 weights[np_starts[i] : np_starts[i + 1]],
             )
         )
+
+
+def test_returns(seed=123):
+    """Test that tsc_parallel returns the allocated ndarray if a grid shape is given,
+    or None if an ndarray is given."""
+
+    from abacusnbody.analysis.tsc import tsc_parallel
+
+    rng = np.random.default_rng(seed)
+    box = 123.0
+    ngrid = 10
+    pos = rng.random((100, 3), dtype='f4') * box
+
+    # Test with grid shape
+    dens = tsc_parallel(pos, ngrid, box)
+    assert dens.shape == (ngrid, ngrid, ngrid)
+
+    # Test with pre-allocated ndarray
+    dens_allocated = np.zeros((ngrid, ngrid, ngrid), dtype=np.float32)
+    dens_returned = tsc_parallel(pos, dens_allocated, box)
+    assert dens_returned is None
+    npt.assert_allclose(dens_allocated, dens)


### PR DESCRIPTION
To make it clear that the given array is being modified in-place. Note: it is not being zeroed before painting, to facilitate incremental painting.